### PR TITLE
Change ISerializer from text-based to binary-based.

### DIFF
--- a/src/StackExchange.Redis.Extensions.Core/ISerializer.cs
+++ b/src/StackExchange.Redis.Extensions.Core/ISerializer.cs
@@ -7,7 +7,7 @@
 		/// </summary>
 		/// <param name="item">The item.</param>
 		/// <returns></returns>
-		string Serialize(object item);
+		byte[] Serialize(object item);
 
 		/// <summary>
 		/// Deserializes the specified bytes.
@@ -16,7 +16,7 @@
 		/// <returns>
 		/// The instance of the specified Item
 		/// </returns>
-		object Deserialize(string serializedObject);
+		object Deserialize(byte[] serializedObject);
 
 		/// <summary>
 		/// Deserializes the specified bytes.
@@ -26,6 +26,6 @@
 		/// <returns>
 		/// The instance of the specified Item
 		/// </returns>
-		T Deserialize<T>(string serializedObject) where T : class;
+		T Deserialize<T>(byte[] serializedObject) where T : class;
 	}
 }

--- a/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
@@ -388,7 +388,7 @@ namespace StackExchange.Redis.Extensions.Core
 
 				if (!redisResults[i].IsNull)
 				{
-					obj = (T) serializer.Deserialize((string)redisResults[i]);
+					obj = (T) serializer.Deserialize((byte[])redisResults[i]);
 				}
 				result.Add(keysList[i], obj);
 			}
@@ -421,7 +421,7 @@ namespace StackExchange.Redis.Extensions.Core
 
 				if (!redisResults[i].IsNull)
 				{
-					obj = (T) serializer.Deserialize((string) redisResults[i]);
+					obj = (T) serializer.Deserialize((byte[]) redisResults[i]);
 				}
 				result.Add(keysList[i], obj);
 			}

--- a/src/StackExchange.Redis.Extensions.Jil/JsonSerializer.cs
+++ b/src/StackExchange.Redis.Extensions.Jil/JsonSerializer.cs
@@ -6,32 +6,32 @@ namespace StackExchange.Redis.Extensions.Jil
 {
 	public class JsonSerializer : ISerializer
 	{
-        // TODO: May make this configurable in the future.
-        /// <summary>
-        /// Encoding to use to convert string to byte[] and the other way around.
-        /// </summary>
-        /// <remarks>
-        /// StackExchange.Redis uses Encoding.UTF8 to convert strings to bytes,
-        /// hence we do same here.
-        /// </remarks>
-	    private static readonly Encoding encoding = Encoding.UTF8;
+		// TODO: May make this configurable in the future.
+		/// <summary>
+		/// Encoding to use to convert string to byte[] and the other way around.
+		/// </summary>
+		/// <remarks>
+		/// StackExchange.Redis uses Encoding.UTF8 to convert strings to bytes,
+		/// hence we do same here.
+		/// </remarks>
+		private static readonly Encoding encoding = Encoding.UTF8;
 
-	    public byte[] Serialize(object item)
+		public byte[] Serialize(object item)
 		{
 			var jsonString = JSON.Serialize(item);
-		    return encoding.GetBytes(jsonString);
+			return encoding.GetBytes(jsonString);
 		}
 
 		public object Deserialize(byte[] serializedObject)
 		{
-		    var jsonString = encoding.GetString(serializedObject);
+			var jsonString = encoding.GetString(serializedObject);
 			return JSON.Deserialize(jsonString, typeof (object));
 		}
 
 		public T Deserialize<T>(byte[] serializedObject) where T : class
 		{
-            var jsonString = encoding.GetString(serializedObject);
-            return JSON.Deserialize<T>(jsonString);
+			var jsonString = encoding.GetString(serializedObject);
+			return JSON.Deserialize<T>(jsonString);
 		}
 	}
 }

--- a/src/StackExchange.Redis.Extensions.Jil/JsonSerializer.cs
+++ b/src/StackExchange.Redis.Extensions.Jil/JsonSerializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Text;
 using Jil;
 using StackExchange.Redis.Extensions.Core;
 
@@ -6,19 +6,32 @@ namespace StackExchange.Redis.Extensions.Jil
 {
 	public class JsonSerializer : ISerializer
 	{
-		public string Serialize(object item)
+        // TODO: May make this configurable in the future.
+        /// <summary>
+        /// Encoding to use to convert string to byte[] and the other way around.
+        /// </summary>
+        /// <remarks>
+        /// StackExchange.Redis uses Encoding.UTF8 to convert strings to bytes,
+        /// hence we do same here.
+        /// </remarks>
+	    private static readonly Encoding encoding = Encoding.UTF8;
+
+	    public byte[] Serialize(object item)
 		{
-			return JSON.Serialize(item);
+			var jsonString = JSON.Serialize(item);
+		    return encoding.GetBytes(jsonString);
 		}
 
-		public object Deserialize(string serializedObject)
+		public object Deserialize(byte[] serializedObject)
 		{
-			return JSON.Deserialize(serializedObject, typeof (object));
+		    var jsonString = encoding.GetString(serializedObject);
+			return JSON.Deserialize(jsonString, typeof (object));
 		}
 
-		public T Deserialize<T>(string serializedObject) where T : class
+		public T Deserialize<T>(byte[] serializedObject) where T : class
 		{
-			return JSON.Deserialize<T>(serializedObject);
+            var jsonString = encoding.GetString(serializedObject);
+            return JSON.Deserialize<T>(jsonString);
 		}
 	}
 }

--- a/src/StackExchange.Redis.Extensions.Newtonsoft/JsonSerializer.cs
+++ b/src/StackExchange.Redis.Extensions.Newtonsoft/JsonSerializer.cs
@@ -6,32 +6,32 @@ namespace StackExchange.Redis.Extensions.Newtonsoft
 {
 	public class JsonSerializer : ISerializer
 	{
-        // TODO: May make this configurable in the future.
-        /// <summary>
-        /// Encoding to use to convert string to byte[] and the other way around.
-        /// </summary>
-        /// <remarks>
-        /// StackExchange.Redis uses Encoding.UTF8 to convert strings to bytes,
-        /// hence we do same here.
-        /// </remarks>
-        private static readonly Encoding encoding = Encoding.UTF8;
+		// TODO: May make this configurable in the future.
+		/// <summary>
+		/// Encoding to use to convert string to byte[] and the other way around.
+		/// </summary>
+		/// <remarks>
+		/// StackExchange.Redis uses Encoding.UTF8 to convert strings to bytes,
+		/// hence we do same here.
+		/// </remarks>
+		private static readonly Encoding encoding = Encoding.UTF8;
 
 		public byte[] Serialize(object item)
 		{
 			var jsonString = JsonConvert.SerializeObject(item);
-            return encoding.GetBytes(jsonString);
+			return encoding.GetBytes(jsonString);
 		}
 
 		public object Deserialize(byte[] serializedObject)
 		{
-            var jsonString = encoding.GetString(serializedObject);
-            return JsonConvert.DeserializeObject(jsonString, typeof(object));
+			var jsonString = encoding.GetString(serializedObject);
+			return JsonConvert.DeserializeObject(jsonString, typeof(object));
 		}
 
 		public T Deserialize<T>(byte[] serializedObject) where T : class
 		{
-            var jsonString = encoding.GetString(serializedObject);
-            return JsonConvert.DeserializeObject<T>(jsonString);
+			var jsonString = encoding.GetString(serializedObject);
+			return JsonConvert.DeserializeObject<T>(jsonString);
 		}
 	}
 }

--- a/src/StackExchange.Redis.Extensions.Newtonsoft/JsonSerializer.cs
+++ b/src/StackExchange.Redis.Extensions.Newtonsoft/JsonSerializer.cs
@@ -1,23 +1,37 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text;
+using Newtonsoft.Json;
 using StackExchange.Redis.Extensions.Core;
 
 namespace StackExchange.Redis.Extensions.Newtonsoft
 {
 	public class JsonSerializer : ISerializer
 	{
-		public string Serialize(object item)
+        // TODO: May make this configurable in the future.
+        /// <summary>
+        /// Encoding to use to convert string to byte[] and the other way around.
+        /// </summary>
+        /// <remarks>
+        /// StackExchange.Redis uses Encoding.UTF8 to convert strings to bytes,
+        /// hence we do same here.
+        /// </remarks>
+        private static readonly Encoding encoding = Encoding.UTF8;
+
+		public byte[] Serialize(object item)
 		{
-			return JsonConvert.SerializeObject(item);
+			var jsonString = JsonConvert.SerializeObject(item);
+            return encoding.GetBytes(jsonString);
 		}
 
-		public object Deserialize(string serializedObject)
+		public object Deserialize(byte[] serializedObject)
 		{
-			return JsonConvert.DeserializeObject(serializedObject, typeof(object));
+            var jsonString = encoding.GetString(serializedObject);
+            return JsonConvert.DeserializeObject(jsonString, typeof(object));
 		}
 
-		public T Deserialize<T>(string serializedObject) where T : class
+		public T Deserialize<T>(byte[] serializedObject) where T : class
 		{
-			return JsonConvert.DeserializeObject<T>(serializedObject);
+            var jsonString = encoding.GetString(serializedObject);
+            return JsonConvert.DeserializeObject<T>(jsonString);
 		}
 	}
 }

--- a/tests/StackExchange.Redis.Extensions.Tests/Helpers/TestItemSerializer.cs
+++ b/tests/StackExchange.Redis.Extensions.Tests/Helpers/TestItemSerializer.cs
@@ -1,23 +1,29 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text;
+using Newtonsoft.Json;
 using StackExchange.Redis.Extensions.Core;
 
 namespace StackExchange.Redis.Extensions.Tests.Helpers
 {
 	public class TestItemSerializer : ISerializer
 	{
-		public string Serialize(object item)
-		{
-			return JsonConvert.SerializeObject(item);
-		}
+        private static readonly Encoding encoding = Encoding.UTF8;
 
-		public object Deserialize(string serializedObject)
-		{
-			return JsonConvert.DeserializeObject(serializedObject, typeof(object));
-		}
+        public byte[] Serialize(object item)
+        {
+            var jsonString = JsonConvert.SerializeObject(item);
+            return encoding.GetBytes(jsonString);
+        }
 
-		public T Deserialize<T>(string serializedObject) where T : class
-		{
-			return JsonConvert.DeserializeObject<T>(serializedObject);
-		}
+        public object Deserialize(byte[] serializedObject)
+        {
+            var jsonString = encoding.GetString(serializedObject);
+            return JsonConvert.DeserializeObject(jsonString, typeof(object));
+        }
+
+        public T Deserialize<T>(byte[] serializedObject) where T : class
+        {
+            var jsonString = encoding.GetString(serializedObject);
+            return JsonConvert.DeserializeObject<T>(jsonString);
+        }
 	}
 }

--- a/tests/StackExchange.Redis.Extensions.Tests/Helpers/TestItemSerializer.cs
+++ b/tests/StackExchange.Redis.Extensions.Tests/Helpers/TestItemSerializer.cs
@@ -6,24 +6,24 @@ namespace StackExchange.Redis.Extensions.Tests.Helpers
 {
 	public class TestItemSerializer : ISerializer
 	{
-        private static readonly Encoding encoding = Encoding.UTF8;
+		private static readonly Encoding encoding = Encoding.UTF8;
 
-        public byte[] Serialize(object item)
-        {
-            var jsonString = JsonConvert.SerializeObject(item);
-            return encoding.GetBytes(jsonString);
-        }
+		public byte[] Serialize(object item)
+		{
+			var jsonString = JsonConvert.SerializeObject(item);
+			return encoding.GetBytes(jsonString);
+		}
 
-        public object Deserialize(byte[] serializedObject)
-        {
-            var jsonString = encoding.GetString(serializedObject);
-            return JsonConvert.DeserializeObject(jsonString, typeof(object));
-        }
+		public object Deserialize(byte[] serializedObject)
+		{
+			var jsonString = encoding.GetString(serializedObject);
+			return JsonConvert.DeserializeObject(jsonString, typeof(object));
+		}
 
-        public T Deserialize<T>(byte[] serializedObject) where T : class
-        {
-            var jsonString = encoding.GetString(serializedObject);
-            return JsonConvert.DeserializeObject<T>(jsonString);
-        }
+		public T Deserialize<T>(byte[] serializedObject) where T : class
+		{
+			var jsonString = encoding.GetString(serializedObject);
+			return JsonConvert.DeserializeObject<T>(jsonString);
+		}
 	}
 }


### PR DESCRIPTION
As per the opened issue #2, this is the change from text-based ISerializer to binary.

Now the serializer produces `byte[]` instead of `string` and deseralized from `byte[]`.

I've run the existing tests and they are green.

Obviously this breaks any backwards compatibility but I don't know if this is an issue.

Fixes #2.