### PR TITLE
Implement basic redis client configuration section

### DIFF
--- a/src/StackExchange.Redis.Extensions.Core/Configuration/IRedisCachingConfiguration.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Configuration/IRedisCachingConfiguration.cs
@@ -6,5 +6,6 @@
         bool AllowAdmin { get; }
         bool Ssl { get; }
         int ConnectTimeout { get; }
+        int Db { get; }
     }
 }

--- a/src/StackExchange.Redis.Extensions.Core/Configuration/IRedisCachingConfiguration.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Configuration/IRedisCachingConfiguration.cs
@@ -1,0 +1,10 @@
+﻿namespace StackExchange.Redis.Extensions.Core.Configuration
+{
+    public interface IRedisCachingConfiguration
+    {
+        RedisHostCollection RedisHosts { get; }
+        bool AllowAdmin { get; }
+        bool Ssl { get; }
+        int ConnectTimeout { get; }
+    }
+}

--- a/src/StackExchange.Redis.Extensions.Core/Configuration/RedisCachingSectionHandler.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Configuration/RedisCachingSectionHandler.cs
@@ -19,11 +19,11 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
             get
             {
                 bool result = false;
-                var o = this["allowAdmin"];
+                var config = this["allowAdmin"];
 
-                if (o != null)
+                if (config != null)
                 {
-                    var value = o.ToString();
+                    var value = config.ToString();
 
                     if (!string.IsNullOrEmpty(value))
                     {
@@ -44,10 +44,10 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
             get
             {
                 bool result = false;
-                var o = this["ssl"];
-                if (o != null)
+                var config = this["ssl"];
+                if (config != null)
                 {
-                    var value = o.ToString();
+                    var value = config.ToString();
                     if (!string.IsNullOrWhiteSpace(value))
                     {
                         if (bool.TryParse(value, out result))
@@ -66,10 +66,10 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
         {
             get
             {
-                var o = this["connectTimeout"];
-                if (o != null)
+                var config = this["connectTimeout"];
+                if (config != null)
                 {
-                    var value = o.ToString();
+                    var value = config.ToString();
                     if (!string.IsNullOrWhiteSpace(value))
                     {
                         int result;
@@ -81,6 +81,29 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
                 }
 
                 return 5000;
+            }
+        }
+
+        [ConfigurationProperty("db")]
+        public int Db
+        {
+            get
+            {
+                var config = this["db"];
+                if (config != null)
+                {
+                    var value = config.ToString();
+                    if (!string.IsNullOrWhiteSpace(value))
+                    {
+                        int result;
+                        if (int.TryParse(value, out result))
+                        {
+                            return result;
+                        }
+                    }
+                }
+
+                return 0;
             }
         }
 

--- a/src/StackExchange.Redis.Extensions.Core/Configuration/RedisCachingSectionHandler.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Configuration/RedisCachingSectionHandler.cs
@@ -1,0 +1,92 @@
+﻿using System.Configuration;
+
+namespace StackExchange.Redis.Extensions.Core.Configuration
+{
+    public class RedisCachingSectionHandler : ConfigurationSection, IRedisCachingConfiguration
+    {
+        [ConfigurationProperty("hosts")]
+        public RedisHostCollection RedisHosts
+        {
+            get
+            {
+                return this["hosts"] as RedisHostCollection;
+            }
+        }
+
+        [ConfigurationProperty("allowAdmin")]
+        public bool AllowAdmin
+        {
+            get
+            {
+                bool result = false;
+                var o = this["allowAdmin"];
+
+                if (o != null)
+                {
+                    var value = o.ToString();
+
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        if (bool.TryParse(value, out result))
+                        {
+                            return result;
+                        }
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        [ConfigurationProperty("ssl")]
+        public bool Ssl
+        {
+            get
+            {
+                bool result = false;
+                var o = this["ssl"];
+                if (o != null)
+                {
+                    var value = o.ToString();
+                    if (!string.IsNullOrWhiteSpace(value))
+                    {
+                        if (bool.TryParse(value, out result))
+                        {
+                            return result;
+                        }
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        [ConfigurationProperty("connectTimeout")]
+        public int ConnectTimeout
+        {
+            get
+            {
+                var o = this["connectTimeout"];
+                if (o != null)
+                {
+                    var value = o.ToString();
+                    if (!string.IsNullOrWhiteSpace(value))
+                    {
+                        int result;
+                        if (int.TryParse(value, out result))
+                        {
+                            return result;
+                        }
+                    }
+                }
+
+                return 5000;
+            }
+        }
+
+        public static RedisCachingSectionHandler GetConfig()
+        {
+            return ConfigurationManager.GetSection("redisCacheClient") as RedisCachingSectionHandler;
+        }
+    }
+}

--- a/src/StackExchange.Redis.Extensions.Core/Configuration/RedisHost.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Configuration/RedisHost.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Configuration;
+
+namespace StackExchange.Redis.Extensions.Core.Configuration
+{
+    public class RedisHost : ConfigurationElement
+    {
+        [ConfigurationProperty("host", IsRequired = true)]
+        public string Host
+        {
+            get
+            {
+                return this["host"] as string;
+            }
+        }
+
+        [ConfigurationProperty("cachePort", IsRequired = true)]
+        public int CachePort
+        {
+            get
+            {
+                var value = this["cachePort"].ToString();
+
+                if (!string.IsNullOrEmpty(value))
+                {
+                    int result;
+
+                    if (int.TryParse(value, out result))
+                    {
+                        return result;
+                    }
+                }
+
+                throw new Exception("Redis Cahe port must be number.");
+            }
+        }
+    }
+}

--- a/src/StackExchange.Redis.Extensions.Core/Configuration/RedisHost.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Configuration/RedisHost.cs
@@ -19,17 +19,22 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
         {
             get
             {
-                var value = this["cachePort"].ToString();
-
-                if (!string.IsNullOrEmpty(value))
+                var config = this["cachePort"];
+                if (config != null)
                 {
-                    int result;
+                    var value = config.ToString();
 
-                    if (int.TryParse(value, out result))
+                    if (!string.IsNullOrEmpty(value))
                     {
-                        return result;
+                        int result;
+
+                        if (int.TryParse(value, out result))
+                        {
+                            return result;
+                        }
                     }
                 }
+
 
                 throw new Exception("Redis Cahe port must be number.");
             }

--- a/src/StackExchange.Redis.Extensions.Core/Configuration/RedisHostCollection.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Configuration/RedisHostCollection.cs
@@ -1,0 +1,34 @@
+﻿using System.Configuration;
+
+namespace StackExchange.Redis.Extensions.Core.Configuration
+{
+    public class RedisHostCollection : ConfigurationElementCollection
+    {
+        public RedisHost this[int index]
+        {
+            get
+            {
+                return BaseGet(index) as RedisHost;
+            }
+            set
+            {
+                if (BaseGet(index) != null)
+                {
+                    BaseRemoveAt(index);
+                }
+
+                BaseAdd(index, value);
+            }
+        }
+
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new RedisHost();
+        }
+
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            return ((RedisHost)element).Host;
+        }
+    }
+}

--- a/src/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.csproj
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.csproj
@@ -46,6 +46,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Configuration\IRedisCachingConfiguration.cs" />
+    <Compile Include="Configuration\RedisCachingSectionHandler.cs" />
+    <Compile Include="Configuration\RedisHost.cs" />
+    <Compile Include="Configuration\RedisHostCollection.cs" />
     <Compile Include="StackExchangeRedisCacheClient.cs" />
     <Compile Include="Extensions\LinqExtensions.cs" />
     <Compile Include="ICacheClient.cs" />

--- a/tests/StackExchange.Redis.Extensions.Tests/App.config
+++ b/tests/StackExchange.Redis.Extensions.Tests/App.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="redisCacheClient"
+           type="StackExchange.Redis.Extensions.Core.Configuration.RedisCachingSectionHandler, StackExchange.Redis.Extensions.Core" />
+  </configSections>
+
+  <redisCacheClient allowAdmin="true" ssl="false" connectTimeout="5000">
+    <hosts>
+      <add host="127.0.0.1" cachePort="6379"/>
+    </hosts>
+  </redisCacheClient>
+</configuration>

--- a/tests/StackExchange.Redis.Extensions.Tests/StackExchange.Redis.Extensions.Tests.csproj
+++ b/tests/StackExchange.Redis.Extensions.Tests/StackExchange.Redis.Extensions.Tests.csproj
@@ -55,6 +55,7 @@
       <HintPath>..\..\packages\StackExchange.Redis.1.0.394\lib\net45\StackExchange.Redis.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
@@ -102,6 +103,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="App.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Example usage;

```xml
  <configSections>
    <section name="redisCacheClient"
           type="StackExchange.Redis.Extensions.Core.Configuration.RedisCachingSectionHandler, StackExchange.Redis.Extensions.Core" />
  </configSections>

  <redisCacheClient allowAdmin="true" ssl="false" connectTimeout="5000">
    <hosts>
      <add host="127.0.0.1" cachePort="6379"/>
    </hosts>
  </redisCacheClient>
```

Code behind;

```csharp
IRedisCachingConfiguration configuration = RedisCachingSectionHandler.GetConfig();

ConfigurationOptions options = new ConfigurationOptions
{
    Ssl = configuration.Ssl,
    AllowAdmin = configuration.AllowAdmin
};
 foreach (RedisHost redisHost in configuration.RedisHosts)
 {
    options.EndPoints.Add(redisHost.Host, redisHost.CachePort);
}

var connectionMultiplexer = ConnectionMultiplexer.Connect(options);
```