### PR TITLE
[FIX] Flush only specified Redis database

### DIFF
--- a/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
@@ -623,7 +623,7 @@ namespace StackExchange.Redis.Extensions.Core
 
 			foreach (var endpoint in endPoints)
 			{
-				db.Multiplexer.GetServer(endpoint).FlushDatabase();
+				db.Multiplexer.GetServer(endpoint).FlushDatabase(db.Database);
 			}
 		}
 
@@ -633,7 +633,7 @@ namespace StackExchange.Redis.Extensions.Core
 
 			foreach (var endpoint in endPoints)
 			{
-				await db.Multiplexer.GetServer(endpoint).FlushDatabaseAsync();
+                await db.Multiplexer.GetServer(endpoint).FlushDatabaseAsync(db.Database);
 			}
 		}
 


### PR DESCRIPTION
The existing implementation Flushes all database. By applying the changes only the specified database will be flushed.