### PR TITLE
Added method on hashes to the StackExchangeRedisCacheClient

### DIFF
--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -1,3 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<solution>
 		<add key="disableSourceControlIntegration" value="true" />

--- a/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
@@ -475,7 +475,6 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(1)
         /// </remarks>
-        /// <param name="client">The redis client used</param>
         /// <param name="hashKey">The key of the hash in redis</param>
         /// <param name="key">The key of the field in the hash</param>
         /// <param name="commandFlags">Command execution flags</param>
@@ -532,6 +531,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <param name="value">the value at field after the increment operation</param>
         long HashIncerementBy(string hashKey, string key, long value, CommandFlags commandFlags = CommandFlags.None);
 
@@ -552,6 +552,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <param name="value">the value at field after the increment operation</param>
         double HashIncerementBy(string hashKey, string key, double value, CommandFlags commandFlags = CommandFlags.None);
 
@@ -627,6 +628,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="pattern">GLOB search pattern</param>
+        /// <param name="pageSize">Number of elements to retrieve from the redis server in the cursor</param>
         /// <param name="commandFlags">Command execution flags</param>
         /// <returns></returns>
         Dictionary<string, T> HashScan<T>(string hashKey, string pattern, int pageSize = 10, CommandFlags commandFlags = CommandFlags.None);
@@ -727,6 +729,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <param name="value">the value at field after the increment operation</param>
         Task<long> HashIncerementByAsync(string hashKey, string key, long value, CommandFlags commandFlags = CommandFlags.None);
 
@@ -826,6 +829,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="pattern">GLOB search pattern</param>
+        /// <param name="pageSize">Number of elements to retrieve from the redis server in the cursor</param>
         /// <param name="commandFlags">Command execution flags</param>
         /// <returns></returns> 
         Task<Dictionary<string, T>> HashScanAsync<T>(string hashKey, string pattern, int pageSize = 10, CommandFlags commandFlags = CommandFlags.None);

--- a/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
@@ -437,5 +437,423 @@ namespace StackExchange.Redis.Extensions.Core
 		/// http://redis.io/commands/rpop
 		/// </remarks>
 		Task<T> ListGetFromRightAsync<T>(string key) where T : class;
-	}
+
+        /// <summary>
+        ///     Removes the specified fields from the hash stored at key. 
+        ///     Specified fields that do not exist within this hash are ignored. 
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(1)
+        /// </remarks>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="key"></param>
+        /// <returns>
+        ///     If key is deleted returns true.
+        ///     If key does not exist, it is treated as an empty hash and this command returns false.
+        /// </returns>
+        bool HashDelete(string hashKey, string key);
+
+        /// <summary>
+        ///     Removes the specified fields from the hash stored at key. 
+        ///     Specified fields that do not exist within this hash are ignored. 
+        ///     If key does not exist, it is treated as an empty hash and this command returns 0.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(N) where N is the number of fields to be removed.
+        /// </remarks>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="keys"></param>
+        /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
+        long HashDelete(string hashKey, IEnumerable<string> keys);
+
+        /// <summary>
+        ///     Removes the specified fields from the hash stored at key. 
+        ///     Specified fields that do not exist within this hash are ignored. 
+        ///     If key does not exist, it is treated as an empty hash and this command returns 0.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(N) where N is the number of fields to be removed.
+        /// </remarks>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="keys"></param>
+        /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
+        long HashDelete(string hashKey, params string[] keys);
+
+        /// <summary>
+        ///     Returns if field is an existing field in the hash stored at key.
+        /// </summary>
+        /// 
+        /// <remarks>
+        ///     Time complexity: O(1)
+        /// </remarks>
+        /// <param name="client">The redis client used</param>
+        /// <param name="hashKey">The key of the hash in redis</param>
+        /// <param name="key">The key of the field in the hash</param>
+        /// <returns>Returns if field is an existing field in the hash stored at key.</returns>
+        bool HashExists(string hashKey, string key);
+
+        /// <summary>
+        ///     Returns the value associated with field in the hash stored at key.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(1)
+        /// </remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="key"></param>
+        /// <returns>the value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
+        T HashGet<T>(string hashKey, string key);
+
+        /// <summary>
+        ///     Returns the values associated with the specified fields in the hash stored at key.
+        ///     For every field that does not exist in the hash, a nil value is returned. 
+        ///     Because a non-existing keys are treated as empty hashes, running HMGET against a non-existing key will return a list of nil values.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(N) where N is the number of fields being requested.
+        /// </remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="keys"></param>
+        /// <returns>list of values associated with the given fields, in the same order as they are requested.</returns>
+        Dictionary<string, T> HashGet<T>(string hashKey, IEnumerable<string> keys);
+
+        /// <summary>
+        ///     Returns all fields and values of the hash stored at key. In the returned value, every field name is followed by its value, so the length of the reply is twice the size of the hash.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(N) where N is the size of the hash.
+        /// </remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <returns>list of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
+        Dictionary<string, T> HashGetAll<T>(string hashKey);
+
+        /// <summary>
+        ///     Increments the number stored at field in the hash stored at key by increment. If key does not exist, a new key holding a hash is created. 
+        ///     If field does not exist the value is set to 0 before the operation is performed.
+        ///     The range of values supported by HINCRBY is limited to 64 bit signed integers.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(1)
+        /// </remarks>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="key"></param>
+        /// <param name="value">the value at field after the increment operation</param>
+        long HashIncerementBy(string hashKey, string key, long value);
+
+        /// <summary>
+        ///     Increment the specified field of an hash stored at key, and representing a floating point number, by the specified increment. 
+        ///     If the field does not exist, it is set to 0 before performing the operation.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         An error is returned if one of the following conditions occur:
+        ///         * The field contains a value of the wrong type (not a string).
+        ///         * The current field content or the specified increment are not parsable as a double precision floating point number.
+        ///     </para>
+        ///     <para>
+        ///         Time complexity: O(1)
+        ///     </para>
+        ///     
+        /// </remarks>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="key"></param>
+        /// <param name="value">the value at field after the increment operation</param>
+        double HashIncerementBy(string hashKey, string key, double value);
+
+        /// <summary>
+        ///     Returns all field names in the hash stored at key.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(N) where N is the size of the hash.
+        /// </remarks>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <returns>list of fields in the hash, or an empty list when key does not exist.</returns>
+        IEnumerable<string> HashKeys(string hashKey);
+
+        /// <summary>
+        ///     Returns the number of fields contained in the hash stored at key.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(1)
+        /// </remarks>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <returns>number of fields in the hash, or 0 when key does not exist.</returns>
+        long HashLength(string hashKey);
+
+        /// <summary>
+        ///     Sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created. If field already exists in the hash, it is overwritten.
+        /// </summary>
+        /// 
+        /// <typeparam name="T"></typeparam>
+        /// <param name="client">The redis client used</param>
+        /// <param name="hashKey">The key of the hash in redis</param>
+        /// <param name="key">The key of the field in the hash</param>
+        /// <param name="nx">Behave like hsetnx - set only if not exists</param>
+        /// <param name="value">The value to be inserted</param>
+        /// <returns>
+        ///     <c>true</c> if field is a new field in the hash and value was set.
+        ///     <c>false</c> if field already exists in the hash and no operation was performed.
+        /// </returns>
+        bool HashSet<T>(string hashKey, string key, T value, bool nx = false);
+
+        /// <summary>
+        ///     Sets the specified fields to their respective values in the hash stored at key. This command overwrites any existing fields in the hash. If key does not exist, a new key holding a hash is created.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(N) where N is the number of fields being set.
+        /// </remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="values"></param>
+        void HashSet<T>(string hashKey, Dictionary<string, T> values);
+
+        /// <summary>
+        ///     Returns all values in the hash stored at key.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(N) where N is the size of the hash.
+        /// </remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="key"></param>
+        /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
+        IEnumerable<T> HashValues<T>(string hashKey, string key);
+
+        /// <summary>
+        ///     iterates fields of Hash types and their associated values.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. 
+        ///     N is the number of elements inside the collection.
+        /// </remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="pattern"></param>
+        /// <returns></returns>
+        IDictionary<string, T> HashScan<T>(string hashKey, string pattern);
+
+        /// <summary>
+        ///     Removes the specified fields from the hash stored at key. 
+        ///     Specified fields that do not exist within this hash are ignored. 
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(1)
+        /// </remarks>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="key"></param>
+        /// <returns>
+        ///     If key is deleted returns true.
+        ///     If key does not exist, it is treated as an empty hash and this command returns false.
+        /// </returns>
+        Task<bool> HashDeleteAsync(string hashKey, string key);
+
+        /// <summary>
+        ///     Removes the specified fields from the hash stored at key. 
+        ///     Specified fields that do not exist within this hash are ignored. 
+        ///     If key does not exist, it is treated as an empty hash and this command returns 0.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(N) where N is the number of fields to be removed.
+        /// </remarks>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="keys"></param>
+        /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
+        Task<long> HashDeleteAsync(string hashKey, IEnumerable<string> keys);
+
+        /// <summary>
+        ///     Removes the specified fields from the hash stored at key. 
+        ///     Specified fields that do not exist within this hash are ignored. 
+        ///     If key does not exist, it is treated as an empty hash and this command returns 0.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(N) where N is the number of fields to be removed.
+        /// </remarks>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="keys"></param>
+        /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
+        Task<long> HashDeleteAsync(string hashKey, params string[] keys);
+
+        /// <summary>
+        ///     Returns if field is an existing field in the hash stored at key.
+        /// </summary>
+        /// 
+        /// <remarks>
+        ///     Time complexity: O(1)
+        /// </remarks>
+        /// <param name="client">The redis client used</param>
+        /// <param name="hashKey">The key of the hash in redis</param>
+        /// <param name="key">The key of the field in the hash</param>
+        /// <returns>Returns if field is an existing field in the hash stored at key.</returns>
+        Task<bool> HashExistsAsync(string hashKey, string key);
+
+        /// <summary>
+        ///     Returns the value associated with field in the hash stored at key.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(1)
+        /// </remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="key"></param>
+        /// <returns>the value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
+        Task<T> HashGetAsync<T>(string hashKey, string key);
+
+        /// <summary>
+        ///     Returns the values associated with the specified fields in the hash stored at key.
+        ///     For every field that does not exist in the hash, a nil value is returned. 
+        ///     Because a non-existing keys are treated as empty hashes, running HMGET against a non-existing key will return a list of nil values.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(N) where N is the number of fields being requested.
+        /// </remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="keys"></param>
+        /// <returns>list of values associated with the given fields, in the same order as they are requested.</returns>
+        Task<Dictionary<string, T>> HashGetAsync<T>(string hashKey, IEnumerable<string> keys);
+
+        /// <summary>
+        ///     Returns all fields and values of the hash stored at key. In the returned value, every field name is followed by its value, so the length of the reply is twice the size of the hash.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(N) where N is the size of the hash.
+        /// </remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <returns>list of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
+        Task<Dictionary<string, T>> HashGetAllAsync<T>(string hashKey);
+
+        /// <summary>
+        ///     Increments the number stored at field in the hash stored at key by increment. If key does not exist, a new key holding a hash is created. 
+        ///     If field does not exist the value is set to 0 before the operation is performed.
+        ///     The range of values supported by HINCRBY is limited to 64 bit signed integers.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(1)
+        /// </remarks>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="key"></param>
+        /// <param name="value">the value at field after the increment operation</param>
+        Task<long> HashIncerementByAsync(string hashKey, string key, long value);
+
+        /// <summary>
+        ///     Increment the specified field of an hash stored at key, and representing a floating point number, by the specified increment. 
+        ///     If the field does not exist, it is set to 0 before performing the operation.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         An error is returned if one of the following conditions occur:
+        ///         * The field contains a value of the wrong type (not a string).
+        ///         * The current field content or the specified increment are not parsable as a double precision floating point number.
+        ///     </para>
+        ///     <para>
+        ///         Time complexity: O(1)
+        ///     </para>
+        ///     
+        /// </remarks>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="key"></param>
+        /// <param name="value">the value at field after the increment operation</param>
+        Task<double> HashIncerementByAsync(string hashKey, string key, double value);
+
+        /// <summary>
+        ///     Returns all field names in the hash stored at key.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(N) where N is the size of the hash.
+        /// </remarks>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <returns>list of fields in the hash, or an empty list when key does not exist.</returns>
+        Task<IEnumerable<string>> HashKeysAsync(string hashKey);
+
+        /// <summary>
+        ///     Returns the number of fields contained in the hash stored at key.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(1)
+        /// </remarks>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <returns>number of fields in the hash, or 0 when key does not exist.</returns>
+        Task<long> HashLengthAsync(string hashKey);
+
+        /// <summary>
+        ///     Sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created. If field already exists in the hash, it is overwritten.
+        /// </summary>
+        /// 
+        /// <typeparam name="T"></typeparam>
+        /// <param name="client">The redis client used</param>
+        /// <param name="hashKey">The key of the hash in redis</param>
+        /// <param name="key">The key of the field in the hash</param>
+        /// <param name="nx">Behave like hsetnx - set only if not exists</param>
+        /// <param name="value">The value to be inserted</param>
+        /// <returns>
+        ///     <c>true</c> if field is a new field in the hash and value was set.
+        ///     <c>false</c> if field already exists in the hash and no operation was performed.
+        /// </returns>
+        Task<bool> HashSetAsync<T>(string hashKey, string key, T value, bool nx = false);
+
+        /// <summary>
+        ///     Sets the specified fields to their respective values in the hash stored at key. This command overwrites any existing fields in the hash. If key does not exist, a new key holding a hash is created.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(N) where N is the number of fields being set.
+        /// </remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="values"></param>
+        Task HashSetAsync<T>(string hashKey, Dictionary<string, T> values);
+
+        /// <summary>
+        ///     Returns all values in the hash stored at key.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(N) where N is the size of the hash.
+        /// </remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="key"></param>
+        /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
+        Task<IEnumerable<T>> HashValuesAsync<T>(string hashKey, string key);
+
+        /// <summary>
+        ///     iterates fields of Hash types and their associated values.
+        /// </summary>
+        /// <remarks>
+        ///     Time complexity: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. 
+        ///     N is the number of elements inside the collection.
+        /// </remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="client"></param>
+        /// <param name="hashKey"></param>
+        /// <param name="pattern"></param>
+        /// <returns></returns>
+        Task<IDictionary<string, T>> HashScanAsync<T>(string hashKey, string pattern);
+    }
 }

--- a/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
@@ -613,10 +613,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
-        /// <param name="key">Key of the entry</param>
         /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
-        IEnumerable<T> HashValues<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None);
+        IEnumerable<T> HashValues<T>(string hashKey, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     iterates fields of Hash types and their associated values.

--- a/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
@@ -447,6 +447,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>
         ///     If key is deleted returns true.
         ///     If key does not exist, it is treated as an empty hash and this command returns false.
@@ -463,6 +464,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys"></param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
         long HashDelete(string hashKey, IEnumerable<string> keys, CommandFlags commandFlags = CommandFlags.None);
 
@@ -476,6 +478,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="client">The redis client used</param>
         /// <param name="hashKey">The key of the hash in redis</param>
         /// <param name="key">The key of the field in the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>Returns if field is an existing field in the hash stored at key.</returns>
         bool HashExists(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None);
 
@@ -488,6 +491,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>the value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
         T HashGet<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None);
 
@@ -502,6 +506,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys"></param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of values associated with the given fields, in the same order as they are requested.</returns>
         Dictionary<string, T> HashGet<T>(string hashKey, IEnumerable<string> keys, CommandFlags commandFlags = CommandFlags.None);
 
@@ -513,6 +518,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
         Dictionary<string, T> HashGetAll<T>(string hashKey, CommandFlags commandFlags = CommandFlags.None);
 
@@ -556,6 +562,7 @@ namespace StackExchange.Redis.Extensions.Core
         ///     Time complexity: O(N) where N is the size of the hash.
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of fields in the hash, or an empty list when key does not exist.</returns>
         IEnumerable<string> HashKeys(string hashKey, CommandFlags commandFlags = CommandFlags.None);
 
@@ -566,6 +573,7 @@ namespace StackExchange.Redis.Extensions.Core
         ///     Time complexity: O(1)
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>number of fields in the hash, or 0 when key does not exist.</returns>
         long HashLength(string hashKey, CommandFlags commandFlags = CommandFlags.None);
 
@@ -578,6 +586,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="key">The key of the field in the hash</param>
         /// <param name="nx">Behave like hsetnx - set only if not exists</param>
         /// <param name="value">The value to be inserted</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>
         ///     <c>true</c> if field is a new field in the hash and value was set.
         ///     <c>false</c> if field already exists in the hash and no operation was performed.
@@ -604,6 +613,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
         IEnumerable<T> HashValues<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None);
 
@@ -617,6 +627,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="pattern">GLOB search pattern</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns></returns>
         Dictionary<string, T> HashScan<T>(string hashKey, string pattern, int pageSize = 10, CommandFlags commandFlags = CommandFlags.None);
 
@@ -630,6 +641,7 @@ namespace StackExchange.Redis.Extensions.Core
 
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>
         ///     If key is deleted returns true.
         ///     If key does not exist, it is treated as an empty hash and this command returns false.
@@ -646,6 +658,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys">Keys to retrieve from the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
         Task<long> HashDeleteAsync(string hashKey, IEnumerable<string> keys, CommandFlags commandFlags = CommandFlags.None);
 
@@ -658,6 +671,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">The key of the hash in redis</param>
         /// <param name="key">The key of the field in the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>Returns if field is an existing field in the hash stored at key.</returns>
         Task<bool> HashExistsAsync(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None);
 
@@ -670,6 +684,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>the value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
         Task<T> HashGetAsync<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None);
 
@@ -684,6 +699,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys">Keys to retrieve from the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of values associated with the given fields, in the same order as they are requested.</returns>
         Task<Dictionary<string, T>> HashGetAsync<T>(string hashKey, IEnumerable<string> keys, CommandFlags commandFlags = CommandFlags.None);
 
@@ -696,6 +712,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
         Task<Dictionary<string, T>> HashGetAllAsync<T>(string hashKey, CommandFlags commandFlags = CommandFlags.None);
 
@@ -731,6 +748,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>the value at field after the increment operation.</returns>
         Task<double> HashIncerementByAsync(string hashKey, string key, double value, CommandFlags commandFlags = CommandFlags.None);
 
@@ -741,6 +759,7 @@ namespace StackExchange.Redis.Extensions.Core
         ///     Time complexity: O(N) where N is the size of the hash.
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of fields in the hash, or an empty list when key does not exist.</returns>
         Task<IEnumerable<string>> HashKeysAsync(string hashKey, CommandFlags commandFlags = CommandFlags.None);
 
@@ -751,6 +770,7 @@ namespace StackExchange.Redis.Extensions.Core
         ///     Time complexity: O(1)
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>number of fields in the hash, or 0 when key does not exist.</returns>
         Task<long> HashLengthAsync(string hashKey, CommandFlags commandFlags = CommandFlags.None);
 
@@ -763,6 +783,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="key">The key of the field in the hash</param>
         /// <param name="nx">Behave like hsetnx - set only if not exists</param>
         /// <param name="value">The value to be inserted</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>
         ///     <c>true</c> if field is a new field in the hash and value was set.
         ///     <c>false</c> if field already exists in the hash and no operation was performed.
@@ -791,6 +812,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
         Task<IEnumerable<T>> HashValuesAsync<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None);
 
@@ -804,6 +826,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="pattern">GLOB search pattern</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns></returns> 
         Task<Dictionary<string, T>> HashScanAsync<T>(string hashKey, string pattern, int pageSize = 10, CommandFlags commandFlags = CommandFlags.None);
     }

--- a/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
@@ -445,9 +445,8 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(1)
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <returns>
         ///     If key is deleted returns true.
         ///     If key does not exist, it is treated as an empty hash and this command returns false.
@@ -462,8 +461,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(N) where N is the number of fields to be removed.
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys"></param>
         /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
         long HashDelete(string hashKey, IEnumerable<string> keys);
@@ -476,8 +474,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(N) where N is the number of fields to be removed.
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys"></param>
         /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
         long HashDelete(string hashKey, params string[] keys);
@@ -501,10 +498,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(1)
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <returns>the value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
         T HashGet<T>(string hashKey, string key);
 
@@ -516,9 +512,8 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(N) where N is the number of fields being requested.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys"></param>
         /// <returns>list of values associated with the given fields, in the same order as they are requested.</returns>
         Dictionary<string, T> HashGet<T>(string hashKey, IEnumerable<string> keys);
@@ -529,9 +524,8 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(N) where N is the size of the hash.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
         /// <returns>list of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
         Dictionary<string, T> HashGetAll<T>(string hashKey);
 
@@ -543,9 +537,8 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(1)
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
         long HashIncerementBy(string hashKey, string key, long value);
 
@@ -564,9 +557,8 @@ namespace StackExchange.Redis.Extensions.Core
         ///     </para>
         ///     
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
         double HashIncerementBy(string hashKey, string key, double value);
 
@@ -576,8 +568,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(N) where N is the size of the hash.
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <param name="hashKey">Key of the hash</param>
         /// <returns>list of fields in the hash, or an empty list when key does not exist.</returns>
         IEnumerable<string> HashKeys(string hashKey);
 
@@ -587,8 +578,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(1)
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <param name="hashKey">Key of the hash</param>
         /// <returns>number of fields in the hash, or 0 when key does not exist.</returns>
         long HashLength(string hashKey);
 
@@ -596,8 +586,7 @@ namespace StackExchange.Redis.Extensions.Core
         ///     Sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created. If field already exists in the hash, it is overwritten.
         /// </summary>
         /// 
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client">The redis client used</param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">The key of the hash in redis</param>
         /// <param name="key">The key of the field in the hash</param>
         /// <param name="nx">Behave like hsetnx - set only if not exists</param>
@@ -614,9 +603,8 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(N) where N is the number of fields being set.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
         /// <param name="values"></param>
         void HashSet<T>(string hashKey, Dictionary<string, T> values);
 
@@ -626,10 +614,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(N) where N is the size of the hash.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
         IEnumerable<T> HashValues<T>(string hashKey, string key);
 
@@ -640,10 +627,9 @@ namespace StackExchange.Redis.Extensions.Core
         ///     Time complexity: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. 
         ///     N is the number of elements inside the collection.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="pattern"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="pattern">GLOB search pattern</param>
         /// <returns></returns>
         IDictionary<string, T> HashScan<T>(string hashKey, string pattern);
 
@@ -654,9 +640,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(1)
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <returns>
         ///     If key is deleted returns true.
         ///     If key does not exist, it is treated as an empty hash and this command returns false.
@@ -671,9 +657,8 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(N) where N is the number of fields to be removed.
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="keys"></param>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="keys">Keys to retrieve from the hash</param>
         /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
         Task<long> HashDeleteAsync(string hashKey, IEnumerable<string> keys);
 
@@ -685,10 +670,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(N) where N is the number of fields to be removed.
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="keys"></param>
-        /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="keys">Keys to retrieve from the hash</param>
+        /// <returns>The number of fields that were removed from the hash, not including specified but non existing fields.</returns>
         Task<long> HashDeleteAsync(string hashKey, params string[] keys);
 
         /// <summary>
@@ -698,7 +682,6 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(1)
         /// </remarks>
-        /// <param name="client">The redis client used</param>
         /// <param name="hashKey">The key of the hash in redis</param>
         /// <param name="key">The key of the field in the hash</param>
         /// <returns>Returns if field is an existing field in the hash stored at key.</returns>
@@ -710,10 +693,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(1)
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <returns>the value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
         Task<T> HashGetAsync<T>(string hashKey, string key);
 
@@ -725,36 +707,35 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(N) where N is the number of fields being requested.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="keys"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="keys">Keys to retrieve from the hash</param>
         /// <returns>list of values associated with the given fields, in the same order as they are requested.</returns>
         Task<Dictionary<string, T>> HashGetAsync<T>(string hashKey, IEnumerable<string> keys);
 
         /// <summary>
-        ///     Returns all fields and values of the hash stored at key. In the returned value, every field name is followed by its value, so the length of the reply is twice the size of the hash.
+        ///     Returns all fields and values of the hash stored at key. In the returned value, 
+        ///     every field name is followed by its value, so the length of the reply is twice the size of the hash.
         /// </summary>
         /// <remarks>
         ///     Time complexity: O(N) where N is the size of the hash.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
         /// <returns>list of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
         Task<Dictionary<string, T>> HashGetAllAsync<T>(string hashKey);
 
         /// <summary>
-        ///     Increments the number stored at field in the hash stored at key by increment. If key does not exist, a new key holding a hash is created. 
+        ///     Increments the number stored at field in the hash stored at key by increment. 
+        ///     If key does not exist, a new key holding a hash is created. 
         ///     If field does not exist the value is set to 0 before the operation is performed.
         ///     The range of values supported by HINCRBY is limited to 64 bit signed integers.
         /// </summary>
         /// <remarks>
         ///     Time complexity: O(1)
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
         Task<long> HashIncerementByAsync(string hashKey, string key, long value);
 
@@ -773,10 +754,10 @@ namespace StackExchange.Redis.Extensions.Core
         ///     </para>
         ///     
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
+        /// <returns>the value at field after the increment operation.</returns>
         Task<double> HashIncerementByAsync(string hashKey, string key, double value);
 
         /// <summary>
@@ -785,8 +766,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(N) where N is the size of the hash.
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <param name="hashKey">Key of the hash</param>
         /// <returns>list of fields in the hash, or an empty list when key does not exist.</returns>
         Task<IEnumerable<string>> HashKeysAsync(string hashKey);
 
@@ -796,8 +776,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(1)
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <param name="hashKey">Key of the hash</param>
         /// <returns>number of fields in the hash, or 0 when key does not exist.</returns>
         Task<long> HashLengthAsync(string hashKey);
 
@@ -805,8 +784,7 @@ namespace StackExchange.Redis.Extensions.Core
         ///     Sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created. If field already exists in the hash, it is overwritten.
         /// </summary>
         /// 
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client">The redis client used</param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">The key of the hash in redis</param>
         /// <param name="key">The key of the field in the hash</param>
         /// <param name="nx">Behave like hsetnx - set only if not exists</param>
@@ -818,14 +796,15 @@ namespace StackExchange.Redis.Extensions.Core
         Task<bool> HashSetAsync<T>(string hashKey, string key, T value, bool nx = false);
 
         /// <summary>
-        ///     Sets the specified fields to their respective values in the hash stored at key. This command overwrites any existing fields in the hash. If key does not exist, a new key holding a hash is created.
+        ///     Sets the specified fields to their respective values in the hash stored at key. 
+        ///     This command overwrites any existing fields in the hash. 
+        ///     If key does not exist, a new key holding a hash is created.
         /// </summary>
         /// <remarks>
         ///     Time complexity: O(N) where N is the number of fields being set.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
         /// <param name="values"></param>
         Task HashSetAsync<T>(string hashKey, Dictionary<string, T> values);
 
@@ -835,10 +814,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(N) where N is the size of the hash.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
         Task<IEnumerable<T>> HashValuesAsync<T>(string hashKey, string key);
 
@@ -849,11 +827,10 @@ namespace StackExchange.Redis.Extensions.Core
         ///     Time complexity: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. 
         ///     N is the number of elements inside the collection.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="pattern"></param>
-        /// <returns></returns>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="pattern">GLOB search pattern</param>
+        /// <returns></returns> 
         Task<IDictionary<string, T>> HashScanAsync<T>(string hashKey, string pattern);
     }
 }

--- a/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
@@ -451,7 +451,7 @@ namespace StackExchange.Redis.Extensions.Core
         ///     If key is deleted returns true.
         ///     If key does not exist, it is treated as an empty hash and this command returns false.
         /// </returns>
-        bool HashDelete(string hashKey, string key);
+        bool HashDelete(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Removes the specified fields from the hash stored at key. 
@@ -464,20 +464,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys"></param>
         /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
-        long HashDelete(string hashKey, IEnumerable<string> keys);
-
-        /// <summary>
-        ///     Removes the specified fields from the hash stored at key. 
-        ///     Specified fields that do not exist within this hash are ignored. 
-        ///     If key does not exist, it is treated as an empty hash and this command returns 0.
-        /// </summary>
-        /// <remarks>
-        ///     Time complexity: O(N) where N is the number of fields to be removed.
-        /// </remarks>
-        /// <param name="hashKey">Key of the hash</param>
-        /// <param name="keys"></param>
-        /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
-        long HashDelete(string hashKey, params string[] keys);
+        long HashDelete(string hashKey, IEnumerable<string> keys, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Returns if field is an existing field in the hash stored at key.
@@ -490,7 +477,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">The key of the hash in redis</param>
         /// <param name="key">The key of the field in the hash</param>
         /// <returns>Returns if field is an existing field in the hash stored at key.</returns>
-        bool HashExists(string hashKey, string key);
+        bool HashExists(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Returns the value associated with field in the hash stored at key.
@@ -502,7 +489,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
         /// <returns>the value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
-        T HashGet<T>(string hashKey, string key);
+        T HashGet<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Returns the values associated with the specified fields in the hash stored at key.
@@ -516,7 +503,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys"></param>
         /// <returns>list of values associated with the given fields, in the same order as they are requested.</returns>
-        Dictionary<string, T> HashGet<T>(string hashKey, IEnumerable<string> keys);
+        Dictionary<string, T> HashGet<T>(string hashKey, IEnumerable<string> keys, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Returns all fields and values of the hash stored at key. In the returned value, every field name is followed by its value, so the length of the reply is twice the size of the hash.
@@ -527,7 +514,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <returns>list of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
-        Dictionary<string, T> HashGetAll<T>(string hashKey);
+        Dictionary<string, T> HashGetAll<T>(string hashKey, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Increments the number stored at field in the hash stored at key by increment. If key does not exist, a new key holding a hash is created. 
@@ -540,7 +527,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
-        long HashIncerementBy(string hashKey, string key, long value);
+        long HashIncerementBy(string hashKey, string key, long value, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Increment the specified field of an hash stored at key, and representing a floating point number, by the specified increment. 
@@ -560,7 +547,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
-        double HashIncerementBy(string hashKey, string key, double value);
+        double HashIncerementBy(string hashKey, string key, double value, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Returns all field names in the hash stored at key.
@@ -570,7 +557,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <returns>list of fields in the hash, or an empty list when key does not exist.</returns>
-        IEnumerable<string> HashKeys(string hashKey);
+        IEnumerable<string> HashKeys(string hashKey, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Returns the number of fields contained in the hash stored at key.
@@ -580,7 +567,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <returns>number of fields in the hash, or 0 when key does not exist.</returns>
-        long HashLength(string hashKey);
+        long HashLength(string hashKey, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created. If field already exists in the hash, it is overwritten.
@@ -595,7 +582,7 @@ namespace StackExchange.Redis.Extensions.Core
         ///     <c>true</c> if field is a new field in the hash and value was set.
         ///     <c>false</c> if field already exists in the hash and no operation was performed.
         /// </returns>
-        bool HashSet<T>(string hashKey, string key, T value, bool nx = false);
+        bool HashSet<T>(string hashKey, string key, T value, bool nx = false, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Sets the specified fields to their respective values in the hash stored at key. This command overwrites any existing fields in the hash. If key does not exist, a new key holding a hash is created.
@@ -606,7 +593,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="values"></param>
-        void HashSet<T>(string hashKey, Dictionary<string, T> values);
+        void HashSet<T>(string hashKey, Dictionary<string, T> values, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Returns all values in the hash stored at key.
@@ -618,7 +605,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
-        IEnumerable<T> HashValues<T>(string hashKey, string key);
+        IEnumerable<T> HashValues<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     iterates fields of Hash types and their associated values.
@@ -631,7 +618,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="pattern">GLOB search pattern</param>
         /// <returns></returns>
-        IDictionary<string, T> HashScan<T>(string hashKey, string pattern);
+        Dictionary<string, T> HashScan<T>(string hashKey, string pattern, int pageSize = 10, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Removes the specified fields from the hash stored at key. 
@@ -647,7 +634,7 @@ namespace StackExchange.Redis.Extensions.Core
         ///     If key is deleted returns true.
         ///     If key does not exist, it is treated as an empty hash and this command returns false.
         /// </returns>
-        Task<bool> HashDeleteAsync(string hashKey, string key);
+        Task<bool> HashDeleteAsync(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Removes the specified fields from the hash stored at key. 
@@ -660,20 +647,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys">Keys to retrieve from the hash</param>
         /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
-        Task<long> HashDeleteAsync(string hashKey, IEnumerable<string> keys);
-
-        /// <summary>
-        ///     Removes the specified fields from the hash stored at key. 
-        ///     Specified fields that do not exist within this hash are ignored. 
-        ///     If key does not exist, it is treated as an empty hash and this command returns 0.
-        /// </summary>
-        /// <remarks>
-        ///     Time complexity: O(N) where N is the number of fields to be removed.
-        /// </remarks>
-        /// <param name="hashKey">Key of the hash</param>
-        /// <param name="keys">Keys to retrieve from the hash</param>
-        /// <returns>The number of fields that were removed from the hash, not including specified but non existing fields.</returns>
-        Task<long> HashDeleteAsync(string hashKey, params string[] keys);
+        Task<long> HashDeleteAsync(string hashKey, IEnumerable<string> keys, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Returns if field is an existing field in the hash stored at key.
@@ -685,7 +659,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">The key of the hash in redis</param>
         /// <param name="key">The key of the field in the hash</param>
         /// <returns>Returns if field is an existing field in the hash stored at key.</returns>
-        Task<bool> HashExistsAsync(string hashKey, string key);
+        Task<bool> HashExistsAsync(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Returns the value associated with field in the hash stored at key.
@@ -697,7 +671,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
         /// <returns>the value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
-        Task<T> HashGetAsync<T>(string hashKey, string key);
+        Task<T> HashGetAsync<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Returns the values associated with the specified fields in the hash stored at key.
@@ -711,7 +685,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys">Keys to retrieve from the hash</param>
         /// <returns>list of values associated with the given fields, in the same order as they are requested.</returns>
-        Task<Dictionary<string, T>> HashGetAsync<T>(string hashKey, IEnumerable<string> keys);
+        Task<Dictionary<string, T>> HashGetAsync<T>(string hashKey, IEnumerable<string> keys, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Returns all fields and values of the hash stored at key. In the returned value, 
@@ -723,7 +697,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <returns>list of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
-        Task<Dictionary<string, T>> HashGetAllAsync<T>(string hashKey);
+        Task<Dictionary<string, T>> HashGetAllAsync<T>(string hashKey, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Increments the number stored at field in the hash stored at key by increment. 
@@ -737,7 +711,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
-        Task<long> HashIncerementByAsync(string hashKey, string key, long value);
+        Task<long> HashIncerementByAsync(string hashKey, string key, long value, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Increment the specified field of an hash stored at key, and representing a floating point number, by the specified increment. 
@@ -758,7 +732,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
         /// <returns>the value at field after the increment operation.</returns>
-        Task<double> HashIncerementByAsync(string hashKey, string key, double value);
+        Task<double> HashIncerementByAsync(string hashKey, string key, double value, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Returns all field names in the hash stored at key.
@@ -768,7 +742,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <returns>list of fields in the hash, or an empty list when key does not exist.</returns>
-        Task<IEnumerable<string>> HashKeysAsync(string hashKey);
+        Task<IEnumerable<string>> HashKeysAsync(string hashKey, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Returns the number of fields contained in the hash stored at key.
@@ -778,7 +752,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <returns>number of fields in the hash, or 0 when key does not exist.</returns>
-        Task<long> HashLengthAsync(string hashKey);
+        Task<long> HashLengthAsync(string hashKey, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created. If field already exists in the hash, it is overwritten.
@@ -793,7 +767,7 @@ namespace StackExchange.Redis.Extensions.Core
         ///     <c>true</c> if field is a new field in the hash and value was set.
         ///     <c>false</c> if field already exists in the hash and no operation was performed.
         /// </returns>
-        Task<bool> HashSetAsync<T>(string hashKey, string key, T value, bool nx = false);
+        Task<bool> HashSetAsync<T>(string hashKey, string key, T value, bool nx = false, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Sets the specified fields to their respective values in the hash stored at key. 
@@ -806,7 +780,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="values"></param>
-        Task HashSetAsync<T>(string hashKey, Dictionary<string, T> values);
+        Task HashSetAsync<T>(string hashKey, IDictionary<string, T> values, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     Returns all values in the hash stored at key.
@@ -818,7 +792,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
-        Task<IEnumerable<T>> HashValuesAsync<T>(string hashKey, string key);
+        Task<IEnumerable<T>> HashValuesAsync<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     iterates fields of Hash types and their associated values.
@@ -831,6 +805,6 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="pattern">GLOB search pattern</param>
         /// <returns></returns> 
-        Task<IDictionary<string, T>> HashScanAsync<T>(string hashKey, string pattern);
+        Task<Dictionary<string, T>> HashScanAsync<T>(string hashKey, string pattern, int pageSize = 10, CommandFlags commandFlags = CommandFlags.None);
     }
 }

--- a/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
@@ -813,10 +813,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
-        /// <param name="key">Key of the entry</param>
         /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
-        Task<IEnumerable<T>> HashValuesAsync<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None);
+        Task<IEnumerable<T>> HashValuesAsync<T>(string hashKey, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
         ///     iterates fields of Hash types and their associated values.

--- a/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
@@ -603,6 +603,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="values"></param>
+        /// <param name="commandFlags">Command execution flags</param>
         void HashSet<T>(string hashKey, Dictionary<string, T> values, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>
@@ -802,7 +803,8 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
-        /// <param name="values"></param>
+        /// <param name="values">The values to be inserted</param>
+        /// <param name="commandFlags">Command execution flags</param>
         Task HashSetAsync<T>(string hashKey, IDictionary<string, T> values, CommandFlags commandFlags = CommandFlags.None);
 
         /// <summary>

--- a/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
@@ -1018,7 +1018,6 @@ namespace StackExchange.Redis.Extensions.Core
         /// <remarks>
         ///     Time complexity: O(1)
         /// </remarks>
-        /// <param name="client">The redis client used</param>
         /// <param name="hashKey">The key of the hash in redis</param>
         /// <param name="key">The key of the field in the hash</param>
         /// <param name="commandFlags">Command execution flags</param>
@@ -1093,6 +1092,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <param name="value">the value at field after the increment operation</param>
         public long HashIncerementBy(string hashKey, string key, long value, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1116,6 +1116,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <param name="value">the value at field after the increment operation</param>
         public double HashIncerementBy(string hashKey, string key, double value, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1210,6 +1211,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="pattern">GLOB search pattern</param>
+        /// <param name="pageSize">Number of elements to retrieve from the redis server in the cursor</param>
         /// <param name="commandFlags">Command execution flags</param>
         /// <returns></returns>
         public Dictionary<string, T> HashScan<T>(string hashKey, string pattern, int pageSize = 10, CommandFlags commandFlags = CommandFlags.None)
@@ -1346,6 +1348,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <param name="value">the value at field after the increment operation</param>
         public async Task<long> HashIncerementByAsync(string hashKey, string key, long value, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1434,6 +1437,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
+        /// <param name="commandFlags">Command executions flags</param>
         /// <param name="values"></param>
         public async Task HashSetAsync<T>(string hashKey, IDictionary<string, T> values, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1467,6 +1471,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="pattern">GLOB search pattern</param>
+        /// <param name="pageSize"></param>
         /// <param name="commandFlags">Command execution flags</param>
         /// <returns></returns>
         public async Task<Dictionary<string, T>> HashScanAsync<T>(string hashKey, string pattern, int pageSize = 10, CommandFlags commandFlags = CommandFlags.None)

--- a/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
@@ -984,6 +984,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>
         ///     If key is deleted returns true.
         ///     If key does not exist, it is treated as an empty hash and this command returns false.
@@ -1003,6 +1004,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys"></param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
         public long HashDelete(string hashKey, IEnumerable<string> keys, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1019,6 +1021,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="client">The redis client used</param>
         /// <param name="hashKey">The key of the hash in redis</param>
         /// <param name="key">The key of the field in the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>Returns if field is an existing field in the hash stored at key.</returns>
         public bool HashExists(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1034,6 +1037,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>the value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
         public T HashGet<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1052,6 +1056,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys"></param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of values associated with the given fields, in the same order as they are requested.</returns>
         public Dictionary<string, T> HashGet<T>(string hashKey, IEnumerable<string> keys, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1067,6 +1072,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
         public Dictionary<string, T> HashGetAll<T>(string hashKey, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1123,6 +1129,7 @@ namespace StackExchange.Redis.Extensions.Core
         ///     Time complexity: O(N) where N is the size of the hash.
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of fields in the hash, or an empty list when key does not exist.</returns>
         public IEnumerable<string> HashKeys(string hashKey, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1136,6 +1143,7 @@ namespace StackExchange.Redis.Extensions.Core
         ///     Time complexity: O(1)
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>number of fields in the hash, or 0 when key does not exist.</returns>
         public long HashLength(string hashKey, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1151,6 +1159,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="key">The key of the field in the hash</param>
         /// <param name="nx">Behave like hsetnx - set only if not exists</param>
         /// <param name="value">The value to be inserted</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>
         ///     <c>true</c> if field is a new field in the hash and value was set.
         ///     <c>false</c> if field already exists in the hash and no operation was performed.
@@ -1184,6 +1193,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
         public IEnumerable<T> HashValues<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1200,6 +1210,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="pattern">GLOB search pattern</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns></returns>
         public Dictionary<string, T> HashScan<T>(string hashKey, string pattern, int pageSize = 10, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1218,6 +1229,7 @@ namespace StackExchange.Redis.Extensions.Core
 
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>
         ///     If key is deleted returns true.
         ///     If key does not exist, it is treated as an empty hash and this command returns false.
@@ -1237,6 +1249,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys">Keys to retrieve from the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
         public async Task<long> HashDeleteAsync(string hashKey, IEnumerable<string> keys, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1252,6 +1265,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">The key of the hash in redis</param>
         /// <param name="key">The key of the field in the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>Returns if field is an existing field in the hash stored at key.</returns>
         public async Task<bool> HashExistsAsync(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1268,6 +1282,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>the value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
         public async Task<T> HashGetAsync<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1286,6 +1301,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys">Keys to retrieve from the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of values associated with the given fields, in the same order as they are requested.</returns>
         public async Task<Dictionary<string, T>> HashGetAsync<T>(string hashKey, IEnumerable<string> keys, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1309,6 +1325,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
         public async Task<Dictionary<string, T>> HashGetAllAsync<T>(string hashKey, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1353,6 +1370,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>the value at field after the increment operation.</returns>
         public async Task<double> HashIncerementByAsync(string hashKey, string key, double value, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1366,6 +1384,7 @@ namespace StackExchange.Redis.Extensions.Core
         ///     Time complexity: O(N) where N is the size of the hash.
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of fields in the hash, or an empty list when key does not exist.</returns>
         public async Task<IEnumerable<string>> HashKeysAsync(string hashKey, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1379,6 +1398,7 @@ namespace StackExchange.Redis.Extensions.Core
         ///     Time complexity: O(1)
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>number of fields in the hash, or 0 when key does not exist.</returns>
         public async Task<long> HashLengthAsync(string hashKey, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1394,6 +1414,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="key">The key of the field in the hash</param>
         /// <param name="nx">Behave like hsetnx - set only if not exists</param>
         /// <param name="value">The value to be inserted</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>
         ///     <c>true</c> if field is a new field in the hash and value was set.
         ///     <c>false</c> if field already exists in the hash and no operation was performed.
@@ -1429,6 +1450,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
         public async Task<IEnumerable<T>> HashValuesAsync<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None)
         {
@@ -1445,6 +1467,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="pattern">GLOB search pattern</param>
+        /// <param name="commandFlags">Command execution flags</param>
         /// <returns></returns>
         public async Task<Dictionary<string, T>> HashScanAsync<T>(string hashKey, string pattern, int pageSize = 10, CommandFlags commandFlags = CommandFlags.None)
         {

--- a/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
@@ -1179,6 +1179,7 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="values"></param>
+        /// <param name="commandFlags">Command execution flags</param>
         public void HashSet<T>(string hashKey, Dictionary<string, T> values, CommandFlags commandFlags = CommandFlags.None)
         {
             var entries = values.Select(kv => new HashEntry(kv.Key, Serializer.Serialize(kv.Value)));

--- a/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
@@ -1221,13 +1221,6 @@ namespace StackExchange.Redis.Extensions.Core
                          .ToDictionary(x => x.Name.ToString(),
                                       x => Serializer.Deserialize<T>(x.Value));
         }
-        /// <summary>
-        ///     Removes the specified fields from the hash stored at key. 
-        ///     Specified fields that do not exist within this hash are ignored. 
-        /// </summary>
-        /// <remarks>
-        ///     Time complexity: O(1)
-        /// </remarks>
 
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>

--- a/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
@@ -1193,10 +1193,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
-        /// <param name="key">Key of the entry</param>
         /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
-        public IEnumerable<T> HashValues<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None)
+        public IEnumerable<T> HashValues<T>(string hashKey, CommandFlags commandFlags = CommandFlags.None)
         {
             return Database.HashValues(hashKey, commandFlags).Select(x => Serializer.Deserialize<T>(x));
         }

--- a/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
@@ -976,18 +976,17 @@ namespace StackExchange.Redis.Extensions.Core
 		}
 
         /// <summary>
-        ///   Removes the specified fields from the hash stored at key. 
-        ///   Specified fields that do not exist within this hash are ignored. 
+        ///     Removes the specified fields from the hash stored at key. 
+        ///     Specified fields that do not exist within this hash are ignored. 
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(1)
+        ///     Time complexity: O(1)
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <returns>
-        ///   If key is deleted returns true.
-        ///   If key does not exist, it is treated as an empty hash and this command returns false.
+        ///     If key is deleted returns true.
+        ///     If key does not exist, it is treated as an empty hash and this command returns false.
         /// </returns>
         public bool HashDelete(string hashKey, string key)
         {
@@ -995,15 +994,14 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Removes the specified fields from the hash stored at key. 
-        ///   Specified fields that do not exist within this hash are ignored. 
-        ///   If key does not exist, it is treated as an empty hash and this command returns 0.
+        ///     Removes the specified fields from the hash stored at key. 
+        ///     Specified fields that do not exist within this hash are ignored. 
+        ///     If key does not exist, it is treated as an empty hash and this command returns 0.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(N) where N is the number of fields to be removed.
+        ///     Time complexity: O(N) where N is the number of fields to be removed.
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys"></param>
         /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
         public long HashDelete(string hashKey, IEnumerable<string> keys)
@@ -1012,15 +1010,14 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Removes the specified fields from the hash stored at key. 
-        ///   Specified fields that do not exist within this hash are ignored. 
-        ///   If key does not exist, it is treated as an empty hash and this command returns 0.
+        ///     Removes the specified fields from the hash stored at key. 
+        ///     Specified fields that do not exist within this hash are ignored. 
+        ///     If key does not exist, it is treated as an empty hash and this command returns 0.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(N) where N is the number of fields to be removed.
+        ///     Time complexity: O(N) where N is the number of fields to be removed.
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys"></param>
         /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
         public long HashDelete(string hashKey, params string[] keys)
@@ -1029,11 +1026,11 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Returns if field is an existing field in the hash stored at key.
+        ///     Returns if field is an existing field in the hash stored at key.
         /// </summary>
         /// 
         /// <remarks>
-        ///   Time complexity: O(1)
+        ///     Time complexity: O(1)
         /// </remarks>
         /// <param name="client">The redis client used</param>
         /// <param name="hashKey">The key of the hash in redis</param>
@@ -1045,15 +1042,14 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Returns the value associated with field in the hash stored at key.
+        ///     Returns the value associated with field in the hash stored at key.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(1)
+        ///     Time complexity: O(1)
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <returns>the value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
         public T HashGet<T>(string hashKey, string key)
         {
@@ -1062,16 +1058,15 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Returns the values associated with the specified fields in the hash stored at key.
-        ///   For every field that does not exist in the hash, a nil value is returned. 
-        ///   Because a non-existing keys are treated as empty hashes, running HMGET against a non-existing key will return a list of nil values.
+        ///     Returns the values associated with the specified fields in the hash stored at key.
+        ///     For every field that does not exist in the hash, a nil value is returned. 
+        ///     Because a non-existing keys are treated as empty hashes, running HMGET against a non-existing key will return a list of nil values.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(N) where N is the number of fields being requested.
+        ///     Time complexity: O(N) where N is the number of fields being requested.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys"></param>
         /// <returns>list of values associated with the given fields, in the same order as they are requested.</returns>
         public Dictionary<string, T> HashGet<T>(string hashKey, IEnumerable<string> keys)
@@ -1081,14 +1076,13 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Returns all fields and values of the hash stored at key. In the returned value, every field name is followed by its value, so the length of the reply is twice the size of the hash.
+        ///     Returns all fields and values of the hash stored at key. In the returned value, every field name is followed by its value, so the length of the reply is twice the size of the hash.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(N) where N is the size of the hash.
+        ///     Time complexity: O(N) where N is the size of the hash.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
         /// <returns>list of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
         public Dictionary<string, T> HashGetAll<T>(string hashKey)
         {
@@ -1100,16 +1094,15 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Increments the number stored at field in the hash stored at key by increment. If key does not exist, a new key holding a hash is created. 
-        ///   If field does not exist the value is set to 0 before the operation is performed.
-        ///   The range of values supported by HINCRBY is limited to 64 bit signed integers.
+        ///     Increments the number stored at field in the hash stored at key by increment. If key does not exist, a new key holding a hash is created. 
+        ///     If field does not exist the value is set to 0 before the operation is performed.
+        ///     The range of values supported by HINCRBY is limited to 64 bit signed integers.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(1)
+        ///     Time complexity: O(1)
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
         public long HashIncerementBy(string hashKey, string key, long value)
         {
@@ -1117,23 +1110,22 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Increment the specified field of an hash stored at key, and representing a floating point number, by the specified increment. 
-        ///   If the field does not exist, it is set to 0 before performing the operation.
+        ///     Increment the specified field of an hash stored at key, and representing a floating point number, by the specified increment. 
+        ///     If the field does not exist, it is set to 0 before performing the operation.
         /// </summary>
         /// <remarks>
-        ///   <para>
-        ///     An error is returned if one of the following conditions occur:
-        ///     * The field contains a value of the wrong type (not a string).
-        ///     * The current field content or the specified increment are not parsable as a double precision floating point number.
-        ///   </para>
-        ///   <para>
-        ///     Time complexity: O(1)
-        ///   </para>
-        ///   
+        ///     <para>
+        ///         An error is returned if one of the following conditions occur:
+        ///         * The field contains a value of the wrong type (not a string).
+        ///         * The current field content or the specified increment are not parsable as a double precision floating point number.
+        ///     </para>
+        ///     <para>
+        ///         Time complexity: O(1)
+        ///     </para>
+        ///     
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
         public double HashIncerementBy(string hashKey, string key, double value)
         {
@@ -1141,13 +1133,12 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Returns all field names in the hash stored at key.
+        ///     Returns all field names in the hash stored at key.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(N) where N is the size of the hash.
+        ///     Time complexity: O(N) where N is the size of the hash.
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <param name="hashKey">Key of the hash</param>
         /// <returns>list of fields in the hash, or an empty list when key does not exist.</returns>
         public IEnumerable<string> HashKeys(string hashKey)
         {
@@ -1155,13 +1146,12 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Returns the number of fields contained in the hash stored at key.
+        ///     Returns the number of fields contained in the hash stored at key.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(1)
+        ///     Time complexity: O(1)
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <param name="hashKey">Key of the hash</param>
         /// <returns>number of fields in the hash, or 0 when key does not exist.</returns>
         public long HashLength(string hashKey)
         {
@@ -1169,18 +1159,17 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created. If field already exists in the hash, it is overwritten.
+        ///     Sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created. If field already exists in the hash, it is overwritten.
         /// </summary>
         /// 
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client">The redis client used</param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">The key of the hash in redis</param>
         /// <param name="key">The key of the field in the hash</param>
         /// <param name="nx">Behave like hsetnx - set only if not exists</param>
         /// <param name="value">The value to be inserted</param>
         /// <returns>
-        ///   <c>true</c> if field is a new field in the hash and value was set.
-        ///   <c>false</c> if field already exists in the hash and no operation was performed.
+        ///     <c>true</c> if field is a new field in the hash and value was set.
+        ///     <c>false</c> if field already exists in the hash and no operation was performed.
         /// </returns>
         public bool HashSet<T>(string hashKey, string key, T value, bool nx = false)
         {
@@ -1188,14 +1177,13 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Sets the specified fields to their respective values in the hash stored at key. This command overwrites any existing fields in the hash. If key does not exist, a new key holding a hash is created.
+        ///     Sets the specified fields to their respective values in the hash stored at key. This command overwrites any existing fields in the hash. If key does not exist, a new key holding a hash is created.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(N) where N is the number of fields being set.
+        ///     Time complexity: O(N) where N is the number of fields being set.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
         /// <param name="values"></param>
         public void HashSet<T>(string hashKey, Dictionary<string, T> values)
         {
@@ -1204,15 +1192,14 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Returns all values in the hash stored at key.
+        ///     Returns all values in the hash stored at key.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(N) where N is the size of the hash.
+        ///     Time complexity: O(N) where N is the size of the hash.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
         public IEnumerable<T> HashValues<T>(string hashKey, string key)
         {
@@ -1220,16 +1207,15 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   iterates fields of Hash types and their associated values.
+        ///     iterates fields of Hash types and their associated values.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. 
-        ///   N is the number of elements inside the collection.
+        ///     Time complexity: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. 
+        ///     N is the number of elements inside the collection.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="pattern"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="pattern">GLOB search pattern</param>
         /// <returns></returns>
         public IDictionary<string, T> HashScan<T>(string hashKey, string pattern)
         {
@@ -1238,20 +1224,19 @@ namespace StackExchange.Redis.Extensions.Core
                          .ToDictionary(x => x.Name.ToString(),
                                       x => Serializer.Deserialize<T>(x.Value));
         }
-
         /// <summary>
-        ///   Removes the specified fields from the hash stored at key. 
-        ///   Specified fields that do not exist within this hash are ignored. 
+        ///     Removes the specified fields from the hash stored at key. 
+        ///     Specified fields that do not exist within this hash are ignored. 
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(1)
+        ///     Time complexity: O(1)
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <returns>
-        ///   If key is deleted returns true.
-        ///   If key does not exist, it is treated as an empty hash and this command returns false.
+        ///     If key is deleted returns true.
+        ///     If key does not exist, it is treated as an empty hash and this command returns false.
         /// </returns>
         public async Task<bool> HashDeleteAsync(string hashKey, string key)
         {
@@ -1259,16 +1244,15 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Removes the specified fields from the hash stored at key. 
-        ///   Specified fields that do not exist within this hash are ignored. 
-        ///   If key does not exist, it is treated as an empty hash and this command returns 0.
+        ///     Removes the specified fields from the hash stored at key. 
+        ///     Specified fields that do not exist within this hash are ignored. 
+        ///     If key does not exist, it is treated as an empty hash and this command returns 0.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(N) where N is the number of fields to be removed.
+        ///     Time complexity: O(N) where N is the number of fields to be removed.
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="keys"></param>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="keys">Keys to retrieve from the hash</param>
         /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
         public async Task<long> HashDeleteAsync(string hashKey, IEnumerable<string> keys)
         {
@@ -1276,30 +1260,28 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Removes the specified fields from the hash stored at key. 
-        ///   Specified fields that do not exist within this hash are ignored. 
-        ///   If key does not exist, it is treated as an empty hash and this command returns 0.
+        ///     Removes the specified fields from the hash stored at key. 
+        ///     Specified fields that do not exist within this hash are ignored. 
+        ///     If key does not exist, it is treated as an empty hash and this command returns 0.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(N) where N is the number of fields to be removed.
+        ///     Time complexity: O(N) where N is the number of fields to be removed.
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="keys"></param>
-        /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="keys">Keys to retrieve from the hash</param>
+        /// <returns>The number of fields that were removed from the hash, not including specified but non existing fields.</returns>
         public async Task<long> HashDeleteAsync(string hashKey, params string[] keys)
         {
             return await Database.HashDeleteAsync(hashKey, keys.Select(x => (RedisValue)x).ToArray());
         }
 
         /// <summary>
-        ///   Returns if field is an existing field in the hash stored at key.
+        ///     Returns if field is an existing field in the hash stored at key.
         /// </summary>
         /// 
         /// <remarks>
-        ///   Time complexity: O(1)
+        ///     Time complexity: O(1)
         /// </remarks>
-        /// <param name="client">The redis client used</param>
         /// <param name="hashKey">The key of the hash in redis</param>
         /// <param name="key">The key of the field in the hash</param>
         /// <returns>Returns if field is an existing field in the hash stored at key.</returns>
@@ -1308,16 +1290,16 @@ namespace StackExchange.Redis.Extensions.Core
             return await Database.HashExistsAsync(hashKey, key);
         }
 
+
         /// <summary>
-        ///   Returns the value associated with field in the hash stored at key.
+        ///     Returns the value associated with field in the hash stored at key.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(1)
+        ///     Time complexity: O(1)
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <returns>the value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
         public async Task<T> HashGetAsync<T>(string hashKey, string key)
         {
@@ -1326,17 +1308,16 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Returns the values associated with the specified fields in the hash stored at key.
-        ///   For every field that does not exist in the hash, a nil value is returned. 
-        ///   Because a non-existing keys are treated as empty hashes, running HMGET against a non-existing key will return a list of nil values.
+        ///     Returns the values associated with the specified fields in the hash stored at key.
+        ///     For every field that does not exist in the hash, a nil value is returned. 
+        ///     Because a non-existing keys are treated as empty hashes, running HMGET against a non-existing key will return a list of nil values.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(N) where N is the number of fields being requested.
+        ///     Time complexity: O(N) where N is the number of fields being requested.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="keys"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="keys">Keys to retrieve from the hash</param>
         /// <returns>list of values associated with the given fields, in the same order as they are requested.</returns>
         public async Task<Dictionary<string, T>> HashGetAsync<T>(string hashKey, IEnumerable<string> keys)
         {
@@ -1352,14 +1333,14 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Returns all fields and values of the hash stored at key. In the returned value, every field name is followed by its value, so the length of the reply is twice the size of the hash.
+        ///     Returns all fields and values of the hash stored at key. In the returned value, 
+        ///     every field name is followed by its value, so the length of the reply is twice the size of the hash.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(N) where N is the size of the hash.
+        ///     Time complexity: O(N) where N is the size of the hash.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
         /// <returns>list of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
         public async Task<Dictionary<string, T>> HashGetAllAsync<T>(string hashKey)
         {
@@ -1371,16 +1352,15 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Increments the number stored at field in the hash stored at key by increment. If key does not exist, a new key holding a hash is created. 
-        ///   If field does not exist the value is set to 0 before the operation is performed.
-        ///   The range of values supported by HINCRBY is limited to 64 bit signed integers.
+        ///     Increments the number stored at field in the hash stored at key by increment. If key does not exist, a new key holding a hash is created. 
+        ///     If field does not exist the value is set to 0 before the operation is performed.
+        ///     The range of values supported by HINCRBY is limited to 64 bit signed integers.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(1)
+        ///     Time complexity: O(1)
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
         public async Task<long> HashIncerementByAsync(string hashKey, string key, long value)
         {
@@ -1388,37 +1368,36 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Increment the specified field of an hash stored at key, and representing a floating point number, by the specified increment. 
-        ///   If the field does not exist, it is set to 0 before performing the operation.
+        ///     Increment the specified field of an hash stored at key, and representing a floating point number, by the specified increment. 
+        ///     If the field does not exist, it is set to 0 before performing the operation.
         /// </summary>
         /// <remarks>
-        ///   <para>
-        ///     An error is returned if one of the following conditions occur:
-        ///     * The field contains a value of the wrong type (not a string).
-        ///     * The current field content or the specified increment are not parsable as a double precision floating point number.
-        ///   </para>
-        ///   <para>
-        ///     Time complexity: O(1)
-        ///   </para>
-        ///   
+        ///     <para>
+        ///         An error is returned if one of the following conditions occur:
+        ///         * The field contains a value of the wrong type (not a string).
+        ///         * The current field content or the specified increment are not parsable as a double precision floating point number.
+        ///     </para>
+        ///     <para>
+        ///         Time complexity: O(1)
+        ///     </para>
+        ///     
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
+        /// <returns>the value at field after the increment operation.</returns>
         public async Task<double> HashIncerementByAsync(string hashKey, string key, double value)
         {
             return await Database.HashIncrementAsync(hashKey, key, value);
         }
 
         /// <summary>
-        ///   Returns all field names in the hash stored at key.
+        ///     Returns all field names in the hash stored at key.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(N) where N is the size of the hash.
+        ///     Time complexity: O(N) where N is the size of the hash.
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <param name="hashKey">Key of the hash</param>
         /// <returns>list of fields in the hash, or an empty list when key does not exist.</returns>
         public async Task<IEnumerable<string>> HashKeysAsync(string hashKey)
         {
@@ -1426,13 +1405,12 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Returns the number of fields contained in the hash stored at key.
+        ///     Returns the number of fields contained in the hash stored at key.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(1)
+        ///     Time complexity: O(1)
         /// </remarks>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <param name="hashKey">Key of the hash</param>
         /// <returns>number of fields in the hash, or 0 when key does not exist.</returns>
         public async Task<long> HashLengthAsync(string hashKey)
         {
@@ -1440,18 +1418,17 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created. If field already exists in the hash, it is overwritten.
+        ///     Sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created. If field already exists in the hash, it is overwritten.
         /// </summary>
         /// 
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client">The redis client used</param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">The key of the hash in redis</param>
         /// <param name="key">The key of the field in the hash</param>
         /// <param name="nx">Behave like hsetnx - set only if not exists</param>
         /// <param name="value">The value to be inserted</param>
         /// <returns>
-        ///   <c>true</c> if field is a new field in the hash and value was set.
-        ///   <c>false</c> if field already exists in the hash and no operation was performed.
+        ///     <c>true</c> if field is a new field in the hash and value was set.
+        ///     <c>false</c> if field already exists in the hash and no operation was performed.
         /// </returns>
         public async Task<bool> HashSetAsync<T>(string hashKey, string key, T value, bool nx = false)
         {
@@ -1459,14 +1436,15 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Sets the specified fields to their respective values in the hash stored at key. This command overwrites any existing fields in the hash. If key does not exist, a new key holding a hash is created.
+        ///     Sets the specified fields to their respective values in the hash stored at key. 
+        ///     This command overwrites any existing fields in the hash. 
+        ///     If key does not exist, a new key holding a hash is created.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(N) where N is the number of fields being set.
+        ///     Time complexity: O(N) where N is the number of fields being set.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
         /// <param name="values"></param>
         public async Task HashSetAsync<T>(string hashKey, Dictionary<string, T> values)
         {
@@ -1475,15 +1453,14 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   Returns all values in the hash stored at key.
+        ///     Returns all values in the hash stored at key.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(N) where N is the size of the hash.
+        ///     Time complexity: O(N) where N is the size of the hash.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="key"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="key">Key of the entry</param>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
         public async Task<IEnumerable<T>> HashValuesAsync<T>(string hashKey, string key)
         {
@@ -1491,16 +1468,15 @@ namespace StackExchange.Redis.Extensions.Core
         }
 
         /// <summary>
-        ///   iterates fields of Hash types and their associated values.
+        ///     iterates fields of Hash types and their associated values.
         /// </summary>
         /// <remarks>
-        ///   Time complexity: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. 
-        ///   N is the number of elements inside the collection.
+        ///     Time complexity: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. 
+        ///     N is the number of elements inside the collection.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="client"></param>
-        /// <param name="hashKey"></param>
-        /// <param name="pattern"></param>
+        /// <typeparam name="T">Type of the returned value</typeparam>
+        /// <param name="hashKey">Key of the hash</param>
+        /// <param name="pattern">GLOB search pattern</param>
         /// <returns></returns>
         public async Task<IDictionary<string, T>> HashScanAsync<T>(string hashKey, string pattern)
         {

--- a/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
@@ -988,9 +988,9 @@ namespace StackExchange.Redis.Extensions.Core
         ///     If key is deleted returns true.
         ///     If key does not exist, it is treated as an empty hash and this command returns false.
         /// </returns>
-        public bool HashDelete(string hashKey, string key)
+        public bool HashDelete(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None)
         {
-            return Database.HashDelete(hashKey, key);
+            return Database.HashDelete(hashKey, key, commandFlags);
         }
 
         /// <summary>
@@ -1004,25 +1004,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys"></param>
         /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
-        public long HashDelete(string hashKey, IEnumerable<string> keys)
+        public long HashDelete(string hashKey, IEnumerable<string> keys, CommandFlags commandFlags = CommandFlags.None)
         {
-            return Database.HashDelete(hashKey, keys.Select(x => (RedisValue)x).ToArray());
-        }
-
-        /// <summary>
-        ///     Removes the specified fields from the hash stored at key. 
-        ///     Specified fields that do not exist within this hash are ignored. 
-        ///     If key does not exist, it is treated as an empty hash and this command returns 0.
-        /// </summary>
-        /// <remarks>
-        ///     Time complexity: O(N) where N is the number of fields to be removed.
-        /// </remarks>
-        /// <param name="hashKey">Key of the hash</param>
-        /// <param name="keys"></param>
-        /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
-        public long HashDelete(string hashKey, params string[] keys)
-        {
-            return Database.HashDelete(hashKey, keys.Select(x => (RedisValue)x).ToArray());
+            return Database.HashDelete(hashKey, keys.Select(x => (RedisValue)x).ToArray(), commandFlags);
         }
 
         /// <summary>
@@ -1036,9 +1020,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">The key of the hash in redis</param>
         /// <param name="key">The key of the field in the hash</param>
         /// <returns>Returns if field is an existing field in the hash stored at key.</returns>
-        public bool HashExists(string hashKey, string key)
+        public bool HashExists(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None)
         {
-            return Database.HashExists(hashKey, key);
+            return Database.HashExists(hashKey, key, commandFlags);
         }
 
         /// <summary>
@@ -1051,9 +1035,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
         /// <returns>the value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
-        public T HashGet<T>(string hashKey, string key)
+        public T HashGet<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None)
         {
-            var redisValue = Database.HashGet(hashKey, key);
+            var redisValue = Database.HashGet(hashKey, key, commandFlags);
             return redisValue.HasValue ? Serializer.Deserialize<T>(redisValue) : default(T);
         }
 
@@ -1069,9 +1053,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys"></param>
         /// <returns>list of values associated with the given fields, in the same order as they are requested.</returns>
-        public Dictionary<string, T> HashGet<T>(string hashKey, IEnumerable<string> keys)
+        public Dictionary<string, T> HashGet<T>(string hashKey, IEnumerable<string> keys, CommandFlags commandFlags = CommandFlags.None)
         {
-            return keys.Select(x => new { key = x, value = HashGet<T>(hashKey, x) })
+            return keys.Select(x => new { key = x, value = HashGet<T>(hashKey, x, commandFlags) })
                         .ToDictionary(kv => kv.key, kv => kv.value);
         }
 
@@ -1084,10 +1068,10 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <returns>list of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
-        public Dictionary<string, T> HashGetAll<T>(string hashKey)
+        public Dictionary<string, T> HashGetAll<T>(string hashKey, CommandFlags commandFlags = CommandFlags.None)
         {
             return Database
-                        .HashGetAll(hashKey)
+                        .HashGetAll(hashKey, commandFlags)
                         .ToDictionary(
                             x => x.Name.ToString(),
                             x => Serializer.Deserialize<T>(x.Value));
@@ -1104,9 +1088,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
-        public long HashIncerementBy(string hashKey, string key, long value)
+        public long HashIncerementBy(string hashKey, string key, long value, CommandFlags commandFlags = CommandFlags.None)
         {
-            return Database.HashIncrement(hashKey, key, value);
+            return Database.HashIncrement(hashKey, key, value, commandFlags);
         }
 
         /// <summary>
@@ -1127,9 +1111,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
-        public double HashIncerementBy(string hashKey, string key, double value)
+        public double HashIncerementBy(string hashKey, string key, double value, CommandFlags commandFlags = CommandFlags.None)
         {
-            return Database.HashIncrement(hashKey, key, value);
+            return Database.HashIncrement(hashKey, key, value, commandFlags);
         }
 
         /// <summary>
@@ -1140,9 +1124,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <returns>list of fields in the hash, or an empty list when key does not exist.</returns>
-        public IEnumerable<string> HashKeys(string hashKey)
+        public IEnumerable<string> HashKeys(string hashKey, CommandFlags commandFlags = CommandFlags.None)
         {
-            return Database.HashKeys(hashKey).Select(x => x.ToString());
+            return Database.HashKeys(hashKey, commandFlags).Select(x => x.ToString());
         }
 
         /// <summary>
@@ -1153,9 +1137,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <returns>number of fields in the hash, or 0 when key does not exist.</returns>
-        public long HashLength(string hashKey)
+        public long HashLength(string hashKey, CommandFlags commandFlags = CommandFlags.None)
         {
-            return Database.HashLength(hashKey);
+            return Database.HashLength(hashKey, commandFlags);
         }
 
         /// <summary>
@@ -1171,9 +1155,9 @@ namespace StackExchange.Redis.Extensions.Core
         ///     <c>true</c> if field is a new field in the hash and value was set.
         ///     <c>false</c> if field already exists in the hash and no operation was performed.
         /// </returns>
-        public bool HashSet<T>(string hashKey, string key, T value, bool nx = false)
+        public bool HashSet<T>(string hashKey, string key, T value, bool nx = false, CommandFlags commandFlags = CommandFlags.None)
         {
-            return Database.HashSet(hashKey, key, Serializer.Serialize(value), nx ? When.NotExists : When.Always);
+            return Database.HashSet(hashKey, key, Serializer.Serialize(value), nx ? When.NotExists : When.Always, commandFlags);
         }
 
         /// <summary>
@@ -1185,10 +1169,10 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="values"></param>
-        public void HashSet<T>(string hashKey, Dictionary<string, T> values)
+        public void HashSet<T>(string hashKey, Dictionary<string, T> values, CommandFlags commandFlags = CommandFlags.None)
         {
             var entries = values.Select(kv => new HashEntry(kv.Key, Serializer.Serialize(kv.Value)));
-            Database.HashSet(hashKey, entries.ToArray());
+            Database.HashSet(hashKey, entries.ToArray(), commandFlags);
         }
 
         /// <summary>
@@ -1201,9 +1185,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
-        public IEnumerable<T> HashValues<T>(string hashKey, string key)
+        public IEnumerable<T> HashValues<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None)
         {
-            return Database.HashValues(hashKey).Select(x => Serializer.Deserialize<T>(x));
+            return Database.HashValues(hashKey, commandFlags).Select(x => Serializer.Deserialize<T>(x));
         }
 
         /// <summary>
@@ -1217,10 +1201,10 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="pattern">GLOB search pattern</param>
         /// <returns></returns>
-        public IDictionary<string, T> HashScan<T>(string hashKey, string pattern)
+        public Dictionary<string, T> HashScan<T>(string hashKey, string pattern, int pageSize = 10, CommandFlags commandFlags = CommandFlags.None)
         {
             return Database
-                         .HashScan(hashKey, pattern)
+                         .HashScan(hashKey, pattern, pageSize, commandFlags)
                          .ToDictionary(x => x.Name.ToString(),
                                       x => Serializer.Deserialize<T>(x.Value));
         }
@@ -1238,9 +1222,9 @@ namespace StackExchange.Redis.Extensions.Core
         ///     If key is deleted returns true.
         ///     If key does not exist, it is treated as an empty hash and this command returns false.
         /// </returns>
-        public async Task<bool> HashDeleteAsync(string hashKey, string key)
+        public async Task<bool> HashDeleteAsync(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None)
         {
-            return await Database.HashDeleteAsync(hashKey, key);
+            return await Database.HashDeleteAsync(hashKey, key, commandFlags);
         }
 
         /// <summary>
@@ -1254,25 +1238,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys">Keys to retrieve from the hash</param>
         /// <returns>Tthe number of fields that were removed from the hash, not including specified but non existing fields.</returns>
-        public async Task<long> HashDeleteAsync(string hashKey, IEnumerable<string> keys)
+        public async Task<long> HashDeleteAsync(string hashKey, IEnumerable<string> keys, CommandFlags commandFlags = CommandFlags.None)
         {
-            return await Database.HashDeleteAsync(hashKey, keys.Select(x => (RedisValue)x).ToArray());
-        }
-
-        /// <summary>
-        ///     Removes the specified fields from the hash stored at key. 
-        ///     Specified fields that do not exist within this hash are ignored. 
-        ///     If key does not exist, it is treated as an empty hash and this command returns 0.
-        /// </summary>
-        /// <remarks>
-        ///     Time complexity: O(N) where N is the number of fields to be removed.
-        /// </remarks>
-        /// <param name="hashKey">Key of the hash</param>
-        /// <param name="keys">Keys to retrieve from the hash</param>
-        /// <returns>The number of fields that were removed from the hash, not including specified but non existing fields.</returns>
-        public async Task<long> HashDeleteAsync(string hashKey, params string[] keys)
-        {
-            return await Database.HashDeleteAsync(hashKey, keys.Select(x => (RedisValue)x).ToArray());
+            return await Database.HashDeleteAsync(hashKey, keys.Select(x => (RedisValue)x).ToArray(), commandFlags);
         }
 
         /// <summary>
@@ -1285,9 +1253,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">The key of the hash in redis</param>
         /// <param name="key">The key of the field in the hash</param>
         /// <returns>Returns if field is an existing field in the hash stored at key.</returns>
-        public async Task<bool> HashExistsAsync(string hashKey, string key)
+        public async Task<bool> HashExistsAsync(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None)
         {
-            return await Database.HashExistsAsync(hashKey, key);
+            return await Database.HashExistsAsync(hashKey, key, commandFlags);
         }
 
 
@@ -1301,9 +1269,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
         /// <returns>the value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
-        public async Task<T> HashGetAsync<T>(string hashKey, string key)
+        public async Task<T> HashGetAsync<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None)
         {
-            var redisValue = await Database.HashGetAsync(hashKey, key);
+            var redisValue = await Database.HashGetAsync(hashKey, key, commandFlags);
             return redisValue.HasValue ? Serializer.Deserialize<T>(redisValue) : default(T);
         }
 
@@ -1319,12 +1287,12 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="keys">Keys to retrieve from the hash</param>
         /// <returns>list of values associated with the given fields, in the same order as they are requested.</returns>
-        public async Task<Dictionary<string, T>> HashGetAsync<T>(string hashKey, IEnumerable<string> keys)
+        public async Task<Dictionary<string, T>> HashGetAsync<T>(string hashKey, IEnumerable<string> keys, CommandFlags commandFlags = CommandFlags.None)
         {
             var result = new Dictionary<string, T>();
             foreach (var key in keys)
             {
-                var value = await HashGetAsync<T>(hashKey, key);
+                var value = await HashGetAsync<T>(hashKey, key, commandFlags);
 
                 result.Add(key, value);
             }
@@ -1342,10 +1310,10 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <returns>list of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
-        public async Task<Dictionary<string, T>> HashGetAllAsync<T>(string hashKey)
+        public async Task<Dictionary<string, T>> HashGetAllAsync<T>(string hashKey, CommandFlags commandFlags = CommandFlags.None)
         {
             return (await Database
-                        .HashGetAllAsync(hashKey))
+                        .HashGetAllAsync(hashKey, commandFlags))
                         .ToDictionary(
                             x => x.Name.ToString(),
                             x => Serializer.Deserialize<T>(x.Value));
@@ -1362,9 +1330,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
-        public async Task<long> HashIncerementByAsync(string hashKey, string key, long value)
+        public async Task<long> HashIncerementByAsync(string hashKey, string key, long value, CommandFlags commandFlags = CommandFlags.None)
         {
-            return await Database.HashIncrementAsync(hashKey, key, value);
+            return await Database.HashIncrementAsync(hashKey, key, value, commandFlags);
         }
 
         /// <summary>
@@ -1386,9 +1354,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="key">Key of the entry</param>
         /// <param name="value">the value at field after the increment operation</param>
         /// <returns>the value at field after the increment operation.</returns>
-        public async Task<double> HashIncerementByAsync(string hashKey, string key, double value)
+        public async Task<double> HashIncerementByAsync(string hashKey, string key, double value, CommandFlags commandFlags = CommandFlags.None)
         {
-            return await Database.HashIncrementAsync(hashKey, key, value);
+            return await Database.HashIncrementAsync(hashKey, key, value, commandFlags);
         }
 
         /// <summary>
@@ -1399,9 +1367,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <returns>list of fields in the hash, or an empty list when key does not exist.</returns>
-        public async Task<IEnumerable<string>> HashKeysAsync(string hashKey)
+        public async Task<IEnumerable<string>> HashKeysAsync(string hashKey, CommandFlags commandFlags = CommandFlags.None)
         {
-            return (await Database.HashKeysAsync(hashKey)).Select(x => x.ToString());
+            return (await Database.HashKeysAsync(hashKey, commandFlags)).Select(x => x.ToString());
         }
 
         /// <summary>
@@ -1412,9 +1380,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <param name="hashKey">Key of the hash</param>
         /// <returns>number of fields in the hash, or 0 when key does not exist.</returns>
-        public async Task<long> HashLengthAsync(string hashKey)
+        public async Task<long> HashLengthAsync(string hashKey, CommandFlags commandFlags = CommandFlags.None)
         {
-            return await Database.HashLengthAsync(hashKey);
+            return await Database.HashLengthAsync(hashKey, commandFlags);
         }
 
         /// <summary>
@@ -1430,9 +1398,9 @@ namespace StackExchange.Redis.Extensions.Core
         ///     <c>true</c> if field is a new field in the hash and value was set.
         ///     <c>false</c> if field already exists in the hash and no operation was performed.
         /// </returns>
-        public async Task<bool> HashSetAsync<T>(string hashKey, string key, T value, bool nx = false)
+        public async Task<bool> HashSetAsync<T>(string hashKey, string key, T value, bool nx = false, CommandFlags commandFlags = CommandFlags.None)
         {
-            return await Database.HashSetAsync(hashKey, key, Serializer.Serialize(value), nx ? When.NotExists : When.Always);
+            return await Database.HashSetAsync(hashKey, key, Serializer.Serialize(value), nx ? When.NotExists : When.Always, commandFlags);
         }
 
         /// <summary>
@@ -1446,10 +1414,10 @@ namespace StackExchange.Redis.Extensions.Core
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="values"></param>
-        public async Task HashSetAsync<T>(string hashKey, Dictionary<string, T> values)
+        public async Task HashSetAsync<T>(string hashKey, IDictionary<string, T> values, CommandFlags commandFlags = CommandFlags.None)
         {
             var entries = values.Select(kv => new HashEntry(kv.Key, Serializer.Serialize(kv.Value)));
-            await Database.HashSetAsync(hashKey, entries.ToArray());
+            await Database.HashSetAsync(hashKey, entries.ToArray(), commandFlags);
         }
 
         /// <summary>
@@ -1462,9 +1430,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="key">Key of the entry</param>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
-        public async Task<IEnumerable<T>> HashValuesAsync<T>(string hashKey, string key)
+        public async Task<IEnumerable<T>> HashValuesAsync<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None)
         {
-            return (await Database.HashValuesAsync(hashKey)).Select(x => Serializer.Deserialize<T>(x));
+            return (await Database.HashValuesAsync(hashKey, commandFlags)).Select(x => Serializer.Deserialize<T>(x));
         }
 
         /// <summary>
@@ -1478,9 +1446,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// <param name="hashKey">Key of the hash</param>
         /// <param name="pattern">GLOB search pattern</param>
         /// <returns></returns>
-        public async Task<IDictionary<string, T>> HashScanAsync<T>(string hashKey, string pattern)
+        public async Task<Dictionary<string, T>> HashScanAsync<T>(string hashKey, string pattern, int pageSize = 10, CommandFlags commandFlags = CommandFlags.None)
         {
-            return (await Task.Run(() => Database.HashScan(hashKey, pattern)))
+            return (await Task.Run(() => Database.HashScan(hashKey, pattern, pageSize, commandFlags)))
                 .ToDictionary(x => x.Name.ToString(), x => Serializer.Deserialize<T>(x.Value));
         }
     }

--- a/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
@@ -1445,10 +1445,9 @@ namespace StackExchange.Redis.Extensions.Core
         /// </remarks>
         /// <typeparam name="T">Type of the returned value</typeparam>
         /// <param name="hashKey">Key of the hash</param>
-        /// <param name="key">Key of the entry</param>
         /// <param name="commandFlags">Command execution flags</param>
         /// <returns>list of values in the hash, or an empty list when key does not exist.</returns>
-        public async Task<IEnumerable<T>> HashValuesAsync<T>(string hashKey, string key, CommandFlags commandFlags = CommandFlags.None)
+        public async Task<IEnumerable<T>> HashValuesAsync<T>(string hashKey, CommandFlags commandFlags = CommandFlags.None)
         {
             return (await Database.HashValuesAsync(hashKey, commandFlags)).Select(x => Serializer.Deserialize<T>(x));
         }

--- a/src/StackExchange.Redis.Extensions.Jil/JilSerializer.cs
+++ b/src/StackExchange.Redis.Extensions.Jil/JilSerializer.cs
@@ -20,6 +20,11 @@ namespace StackExchange.Redis.Extensions.Jil
         /// hence we do same here.
         /// </remarks>
         private static readonly Encoding encoding = Encoding.UTF8;
+
+        /// <summary>
+        /// Default constructor for Jil serializer.
+        /// </summary>
+        /// This constructor uses default serialization options.
         public JilSerializer()
             : this(new Options(prettyPrint: true, 
                 excludeNulls: false, 
@@ -32,6 +37,9 @@ namespace StackExchange.Redis.Extensions.Jil
 
         }
 
+        /// <summary>
+        /// Constructor for Jil serializer.
+        /// </summary>
         public JilSerializer(Options options)
         {
             if (options == null) throw new ArgumentNullException(nameof(options));

--- a/src/StackExchange.Redis.Extensions.Jil/JilSerializer.cs
+++ b/src/StackExchange.Redis.Extensions.Jil/JilSerializer.cs
@@ -2,87 +2,105 @@
 using System.Threading.Tasks;
 using Jil;
 using StackExchange.Redis.Extensions.Core;
+using System;
 
 namespace StackExchange.Redis.Extensions.Jil
 {
-	/// <summary>
-	/// Jil implementation of <see cref="ISerializer"/>
-	/// </summary>
-	public class JilSerializer : ISerializer
-	{
-		// TODO: May make this configurable in the future.
-		/// <summary>
-		/// Encoding to use to convert string to byte[] and the other way around.
-		/// </summary>
-		/// <remarks>
-		/// StackExchange.Redis uses Encoding.UTF8 to convert strings to bytes,
-		/// hence we do same here.
-		/// </remarks>
-		private static readonly Encoding encoding = Encoding.UTF8;
+    /// <summary>
+    /// Jil implementation of <see cref="ISerializer"/>
+    /// </summary>
+    public class JilSerializer : ISerializer
+    {
+        // TODO: May make this configurable in the future.
+        /// <summary>
+        /// Encoding to use to convert string to byte[] and the other way around.
+        /// </summary>
+        /// <remarks>
+        /// StackExchange.Redis uses Encoding.UTF8 to convert strings to bytes,
+        /// hence we do same here.
+        /// </remarks>
+        private static readonly Encoding encoding = Encoding.UTF8;
+        public JilSerializer()
+            : this(new Options(prettyPrint: true, 
+                excludeNulls: false, 
+                jsonp: false, 
+                dateFormat: 
+                DateTimeFormat.ISO8601, 
+                includeInherited: true, 
+                unspecifiedDateTimeKindBehavior: UnspecifiedDateTimeKindBehavior.IsLocal))
+        {
 
-		/// <summary>
-		/// Serializes the specified item.
-		/// </summary>
-		/// <param name="item">The item.</param>
-		/// <returns></returns>
-		public byte[] Serialize(object item)
-		{
-			var jsonString = JSON.Serialize(item);
-			return encoding.GetBytes(jsonString);
-		}
+        }
 
-		/// <summary>
-		/// Serializes the asynchronous.
-		/// </summary>
-		/// <param name="item">The item.</param>
-		/// <returns></returns>
-		public Task<byte[]> SerializeAsync(object item)
-		{
-			return Task.Factory.StartNew(() => Serialize(item));
-		}
+        public JilSerializer(Options options)
+        {
+            if (options == null) throw new ArgumentNullException(nameof(options));
 
-		/// <summary>
-		/// Deserializes the specified serialized object.
-		/// </summary>
-		/// <param name="serializedObject">The serialized object.</param>
-		/// <returns></returns>
-		public object Deserialize(byte[] serializedObject)
-		{
-			var jsonString = encoding.GetString(serializedObject);
-			return JSON.Deserialize(jsonString, typeof (object));
-		}
+            JSON.SetDefaultOptions(options);
+        }
+        /// <summary>
+        /// Serializes the specified item.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <returns></returns>
+        public byte[] Serialize(object item)
+        {
+            var jsonString = JSON.Serialize(item);
+            return encoding.GetBytes(jsonString);
+        }
 
-		/// <summary>
-		/// Deserializes the asynchronous.
-		/// </summary>
-		/// <param name="serializedObject">The serialized object.</param>
-		/// <returns></returns>
-		public Task<object> DeserializeAsync(byte[] serializedObject)
-		{
-			return Task.Factory.StartNew(() => Deserialize(serializedObject));
-		}
+        /// <summary>
+        /// Serializes the asynchronous.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <returns></returns>
+        public Task<byte[]> SerializeAsync(object item)
+        {
+            return Task.Factory.StartNew(() => Serialize(item));
+        }
 
-		/// <summary>
-		/// Deserializes the specified serialized object.
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="serializedObject">The serialized object.</param>
-		/// <returns></returns>
-		public T Deserialize<T>(byte[] serializedObject)
-		{
-			var jsonString = encoding.GetString(serializedObject);
-			return JSON.Deserialize<T>(jsonString);
-		}
+        /// <summary>
+        /// Deserializes the specified serialized object.
+        /// </summary>
+        /// <param name="serializedObject">The serialized object.</param>
+        /// <returns></returns>
+        public object Deserialize(byte[] serializedObject)
+        {
+            var jsonString = encoding.GetString(serializedObject);
+            return JSON.Deserialize(jsonString, typeof(object));
+        }
 
-		/// <summary>
-		/// Deserializes the asynchronous.
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="serializedObject">The serialized object.</param>
-		/// <returns></returns>
-		public Task<T> DeserializeAsync<T>(byte[] serializedObject)
-		{
-			return Task.Factory.StartNew(() => Deserialize<T>(serializedObject));
-		}
-	}
+        /// <summary>
+        /// Deserializes the asynchronous.
+        /// </summary>
+        /// <param name="serializedObject">The serialized object.</param>
+        /// <returns></returns>
+        public Task<object> DeserializeAsync(byte[] serializedObject)
+        {
+            return Task.Factory.StartNew(() => Deserialize(serializedObject));
+        }
+
+        /// <summary>
+        /// Deserializes the specified serialized object.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="serializedObject">The serialized object.</param>
+        /// <returns></returns>
+        public T Deserialize<T>(byte[] serializedObject)
+        {
+            var jsonString = encoding.GetString(serializedObject);
+            return JSON.Deserialize<T>(jsonString);
+        }
+
+        /// <summary>
+        /// Deserializes the asynchronous.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="serializedObject">The serialized object.</param>
+        /// <returns></returns>
+        public Task<T> DeserializeAsync<T>(byte[] serializedObject)
+        {
+            return Task.Factory.StartNew(() => Deserialize<T>(serializedObject));
+        }
+    }
 }

--- a/src/StackExchange.Redis.Extensions.Newtonsoft/CachedObject.cs
+++ b/src/StackExchange.Redis.Extensions.Newtonsoft/CachedObject.cs
@@ -1,6 +1,6 @@
 ﻿namespace StackExchange.Redis.Extensions.Newtonsoft
 {
-	internal class CachedObject<T>
+	public class CachedObject<T>
 	{
 		private CachedObject()
 		{

--- a/src/StackExchange.Redis.Extensions.Newtonsoft/CachedObject.cs
+++ b/src/StackExchange.Redis.Extensions.Newtonsoft/CachedObject.cs
@@ -1,16 +1,23 @@
 ﻿namespace StackExchange.Redis.Extensions.Newtonsoft
 {
+    /// <summary>
+    /// This class is used a wrapper for serialized content.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
 	public class CachedObject<T>
 	{
-		private CachedObject()
-		{
-		}
-
+        /// <summary>
+        /// Constructor for CacheObject wraper
+        /// </summary>
+        /// <param name="cachedValue">The cache value</param>
 		public CachedObject(T cachedValue)
 		{
 			CachedValue = cachedValue;
 		}
 
+        /// <summary>
+        /// The cache content
+        /// </summary>
 		public T CachedValue { get; set; }
 	}
 }

--- a/src/StackExchange.Redis.Extensions.Newtonsoft/NewtonsoftSerializer.cs
+++ b/src/StackExchange.Redis.Extensions.Newtonsoft/NewtonsoftSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Globalization;
+using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using StackExchange.Redis.Extensions.Core;
@@ -20,6 +21,13 @@ namespace StackExchange.Redis.Extensions.Newtonsoft
 		/// </remarks>
 		private static readonly Encoding encoding = Encoding.UTF8;
 
+	    private readonly JsonSerializerSettings settings;
+
+	    public NewtonsoftSerializer(JsonSerializerSettings settings = null)
+	    {
+	        this.settings = settings ?? new JsonSerializerSettings();
+	    }
+
 		/// <summary>
 		/// Serializes the specified item.
 		/// </summary>
@@ -28,7 +36,7 @@ namespace StackExchange.Redis.Extensions.Newtonsoft
 		public byte[] Serialize(object item)
 		{
 			var co = new CachedObject<object>(item);
-			var jsonString = JsonConvert.SerializeObject(co);
+			var jsonString = JsonConvert.SerializeObject(co, settings);
 			return encoding.GetBytes(jsonString);
 		}
 
@@ -40,7 +48,7 @@ namespace StackExchange.Redis.Extensions.Newtonsoft
 		public async Task<byte[]> SerializeAsync(object item)
 		{
 			var co = new CachedObject<object>(item);
-			var jsonString = await Task.Factory.StartNew(() => JsonConvert.SerializeObject(co));
+			var jsonString = await Task.Factory.StartNew(() => JsonConvert.SerializeObject(co, settings));
 			return encoding.GetBytes(jsonString);
 		}
 
@@ -74,7 +82,7 @@ namespace StackExchange.Redis.Extensions.Newtonsoft
 		public T Deserialize<T>(byte[] serializedObject)
 		{
 			var jsonString = encoding.GetString(serializedObject);
-			return JsonConvert.DeserializeObject<CachedObject<T>>(jsonString).CachedValue;
+			return JsonConvert.DeserializeObject<CachedObject<T>>(jsonString, settings).CachedValue;
 		}
 
 		/// <summary>

--- a/src/StackExchange.Redis.Extensions.Newtonsoft/NewtonsoftSerializer.cs
+++ b/src/StackExchange.Redis.Extensions.Newtonsoft/NewtonsoftSerializer.cs
@@ -21,6 +21,11 @@ namespace StackExchange.Redis.Extensions.Newtonsoft
 		private static readonly Encoding encoding = Encoding.UTF8;
 
 	    private readonly JsonSerializerSettings settings;
+
+        /// <summary>
+        /// Constructor for NewtonsoftJson serializer
+        /// </summary>
+        /// <param name="settings"></param>
 	    public NewtonsoftSerializer(JsonSerializerSettings settings = null)
 	    {
 	        this.settings = settings ?? new JsonSerializerSettings();

--- a/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
+++ b/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
@@ -352,18 +352,31 @@ namespace StackExchange.Redis.Extensions.Tests
 		}
 
 		[Fact]
-		public void SetAddAsyncGenericShouldThrowExceptionWhenKeyIsEmpty()
+		public async Task SetAddAsyncGenericShouldThrowExceptionWhenKeyIsEmpty()
 		{
-			var exceptions = Sut.SetAddAsync<string>(string.Empty, string.Empty).Exception;
-			Assert.IsType<ArgumentException>(exceptions.Flatten().GetBaseException());
+		    try
+		    {
+		        await Sut.SetAddAsync<string>(string.Empty, string.Empty);
+		    }
+		    catch (Exception ex)
+		    {
+                Assert.IsType<ArgumentException>(ex);
+            }
+            
 		}
 
 		[Fact]
-		public void SetAddAsyncGenericShouldThrowExceptionWhenItemIsNull()
+		public async Task SetAddAsyncGenericShouldThrowExceptionWhenItemIsNull()
 		{
-			var exceptions = Sut.SetAddAsync<string>("MySet", null).Exception;
-			Assert.IsType<ArgumentNullException>(exceptions.Flatten().GetBaseException());
-		}
+		    try
+		    {
+		        await Sut.SetAddAsync<string>("MySet", null);
+		    }
+            catch (Exception ex)
+            { 
+			Assert.IsType<ArgumentNullException>(ex);
+            }
+        }
 
 		[Fact]
 		public async Task SetAddAsyncGeneric_With_An_Existing_Key_Should_Return_Valid_Data()
@@ -416,17 +429,30 @@ namespace StackExchange.Redis.Extensions.Tests
 		}
 
 		[Fact]
-		public void ListAddToLeftAsyncGenericShouldThrowExceptionWhenKeyIsEmpty()
+		public async Task ListAddToLeftAsyncGenericShouldThrowExceptionWhenKeyIsEmpty()
 		{
-			var exceptions = Sut.ListAddToLeftAsync(string.Empty, string.Empty).Exception;
-			Assert.IsType<ArgumentException>(exceptions.Flatten().GetBaseException());
-		}
+		    try
+		    {
+                await Sut.ListAddToLeftAsync(string.Empty, string.Empty);
+            }
+		    catch (Exception ex)
+		    {
+                Assert.IsType<ArgumentException>(ex);
+            }
+
+        }
 
 		[Fact]
-		public void ListAddToLeftAsyncGenericShouldThrowExceptionWhenItemIsNull()
+		public async Task ListAddToLeftAsyncGenericShouldThrowExceptionWhenItemIsNull()
 		{
-			var exceptions = Sut.ListAddToLeftAsync<string>("MyList", null).Exception;
-			Assert.IsType<ArgumentNullException>(exceptions.Flatten().GetBaseException());
+            try
+            {
+                await Sut.ListAddToLeftAsync<string>("MyList", null);
+            }
+            catch (Exception ex)
+            {
+                Assert.IsType<ArgumentNullException>(ex);
+            }
 		}
 
 		[Fact]
@@ -474,10 +500,16 @@ namespace StackExchange.Redis.Extensions.Tests
 		}
 
 		[Fact]
-		public void ListGetFromRightAsyncGenericShouldThrowExceptionWhenKeyIsEmpty()
+		public async Task ListGetFromRightAsyncGenericShouldThrowExceptionWhenKeyIsEmpty()
 		{
-			var exceptions = Sut.ListGetFromRightAsync<string>(string.Empty).Exception;
-			Assert.IsType<ArgumentException>(exceptions.Flatten().GetBaseException());
+		    try
+		    {
+                await Sut.ListGetFromRightAsync<string>(string.Empty);
+            }
+            catch (Exception ex)
+		    {
+                Assert.IsType<ArgumentException>(ex);
+		    }
 		}
 
 		[Fact]

--- a/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
+++ b/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
@@ -534,7 +534,7 @@ namespace StackExchange.Redis.Extensions.Tests
             Assert.Equal(initialValue, data);
         }
 
-        //[Fact] // TODO: NX doesn't work for some reason
+        [Fact] // TODO: NX doesn't work for some reason
         public void HashSetSingleValue_ValueExists_ShouldUpdateValue()
         {
             // arrange

--- a/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
+++ b/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
@@ -1,10 +1,14 @@
 ﻿using System;
+using System.CodeDom;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FizzWare.NBuilder;
+using Newtonsoft.Json;
 using StackExchange.Redis.Extensions.Core;
 using StackExchange.Redis.Extensions.Core.Extensions;
 using StackExchange.Redis.Extensions.Tests.Extensions;
@@ -483,5 +487,112 @@ namespace StackExchange.Redis.Extensions.Tests
 			Assert.Equal(item.Key, values[0].Key);
 			Assert.Equal(item.Value, values[0].Value);
 		}
-	}
+
+        // Hash tests
+
+
+        // HashDelete
+        // HashDelete multiple
+        // HashExists
+        // HashGet
+        // HashGet multiple
+        // HashGetAll
+        // HashIncerementBy long
+        // HashIncerementBy double
+        // HashKeys
+        // HashLength
+        // HashSet
+        // HashSet multiple
+        // HashValues
+        // HashScan
+
+        // async variants
+
+        /*
+	    [Fact]
+	    public void Some_Test_Template()
+	    {
+            // arrange
+            // act
+            // assert
+        }
+        */
+
+        [Fact]
+        public void HashSetSingleValueNX_ValueDoesntExists_ShouldInsertValue()
+        {
+            // arrange
+            var hashKey = Guid.NewGuid().ToString();
+            var entryKey = Guid.NewGuid().ToString();
+            var entryValue = new TestClass<DateTime>("test", DateTime.UtcNow);
+            
+            // act
+            var res = Sut.HashSet(hashKey, entryKey, entryValue, nx: true);
+
+            // assert
+            Assert.True(res);
+            var data = Sut.HashGet<TestClass<DateTime>>(hashKey, entryKey);
+            Assert.Equal(entryValue, data);
+        }
+
+        [Fact]
+        public void HashSetSingleValueNX_ValueExists_ShouldNotInsertValue()
+        {
+            // arrange
+            var hashKey = Guid.NewGuid().ToString();
+            var entryKey = Guid.NewGuid().ToString();
+            var entryValue = new TestClass<DateTime>("test1", DateTime.UtcNow);
+            var initialValue = new TestClass<DateTime>("test2", DateTime.UtcNow);
+            var initRes = Sut.HashSet(hashKey, entryKey, initialValue);
+
+            // act
+            var res = Sut.HashSet(hashKey, entryKey, entryValue, nx: true);
+
+            // assert
+            Assert.True(initRes);
+            Assert.False(res);
+            var data = Sut.HashGet<TestClass<DateTime>>(hashKey, entryKey);
+            Assert.Equal(initialValue, data);
+        }
+
+        [Fact]
+        public void HashSetSingleValue_ValueExists_ShouldUpdateValue()
+        {
+            // arrange
+            var hashKey = Guid.NewGuid().ToString();
+            var entryKey = Guid.NewGuid().ToString();
+            var entryValue = new TestClass<DateTime>("test1", DateTime.UtcNow);
+            var initialValue = new TestClass<DateTime>("test2", DateTime.UtcNow);
+            var initRes = Sut.HashSet(hashKey, entryKey, initialValue);
+
+            // act
+            var res = Sut.HashSet(hashKey, entryKey, entryValue, true);
+
+            // assert
+            Assert.True(initRes);
+            Assert.True(res);
+            var data = Sut.HashGet<TestClass<DateTime>>(hashKey, entryKey);
+            Assert.Equal(entryValue, data);
+        }
+
+        [Fact]
+        public void HashSetMultipleValue_ShouldInsertAllValues()
+        {
+            // arrange
+            var hashKey = Guid.NewGuid().ToString();
+            var values = Builder<TestClass<DateTime>>.CreateListOfSize(100).All().Build();
+            var map = values.ToDictionary(val => Guid.NewGuid().ToString());
+
+            // act
+            Sut.HashSet(hashKey, map);
+
+            // assert
+            var data = Sut.HashGet<TestClass<DateTime>>(hashKey, map.Keys);
+            Assert.Equal(map.Count, data.Count);
+            foreach (var key in data.Keys)
+            {
+                Assert.True(map.ContainsKey(key));
+            }
+        }
+    }
 }

--- a/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
+++ b/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
@@ -36,7 +36,7 @@ namespace StackExchange.Redis.Extensions.Tests
 		}
 
 		[Fact]
-		public void Info_Should_Return_Valid_Informatino()
+		public void Info_Should_Return_Valid_Information()
 		{
 			var response = Sut.GetInfo();
 

--- a/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
+++ b/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
@@ -1031,7 +1031,7 @@ namespace StackExchange.Redis.Extensions.Tests
             Assert.Equal(map.Count, data.Count());
             foreach (var val in data)
             {
-                Assert.True(map.ContainsValue(val), $"result map doesn't contain value: {val}");
+                Assert.True(map.ContainsValue(val), $"result map doesn't contain value: {val.Key}:{val.Value}");
             }
         }
 

--- a/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
+++ b/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
@@ -15,6 +15,8 @@ using StackExchange.Redis.Extensions.Tests.Extensions;
 using StackExchange.Redis.Extensions.Tests.Helpers;
 using Xunit;
 
+using static System.Linq.Enumerable;
+
 namespace StackExchange.Redis.Extensions.Tests
 {
 	[Collection("Redis")]
@@ -559,12 +561,12 @@ namespace StackExchange.Redis.Extensions.Tests
         {
             // arrange
             var hashKey = Guid.NewGuid().ToString();
-            var values = Builder<TestClass<DateTime>>.CreateListOfSize(100).All().Build();
+            var values = Range(0, 100).Select(_ => new TestClass<DateTime>(Guid.NewGuid().ToString(), DateTime.UtcNow));
             var map = values.ToDictionary(val => Guid.NewGuid().ToString());
 
             // act
             Sut.HashSet(hashKey, map);
-
+            Thread.Sleep(500);
             // assert
             var data = Sut.Database
                         .HashGet(hashKey, map.Keys.Select(x => (RedisValue)x).ToArray()).ToList()
@@ -1016,7 +1018,7 @@ namespace StackExchange.Redis.Extensions.Tests
         {
             // arrange
             var hashKey = Guid.NewGuid().ToString();
-            var values = Builder<TestClass<DateTime>>.CreateListOfSize(100).All().Build();
+            var values = Range(0, 100).Select(_ => new TestClass<DateTime>(Guid.NewGuid().ToString(), DateTime.UtcNow));
             var map = values.ToDictionary(val => Guid.NewGuid().ToString());
 
             // act

--- a/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
+++ b/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
@@ -536,7 +536,7 @@ namespace StackExchange.Redis.Extensions.Tests
             Assert.Equal(initialValue, data);
         }
 
-        [Fact] // TODO: NX doesn't work for some reason
+        [Fact]
         public void HashSetSingleValue_ValueExists_ShouldUpdateValue()
         {
             // arrange
@@ -547,11 +547,11 @@ namespace StackExchange.Redis.Extensions.Tests
             var initRes = Sut.Database.HashSet(hashKey, entryKey, Serializer.Serialize(initialValue));
 
             // act
-            var res = Sut.HashSet(hashKey, entryKey, entryValue, true);
+            var res = Sut.HashSet(hashKey, entryKey, entryValue, nx: false);
 
             // assert
-            Assert.True(initRes);
-            Assert.True(res);
+            Assert.True(initRes, "Initial value was not set");
+            Assert.False(res); // NOTE: HSET returns: 1 if new field was created and value set, or 0 if field existed and value set. reference: http://redis.io/commands/HSET
             var data = Serializer.Deserialize<TestClass<DateTime>>(Sut.Database.HashGet(hashKey, entryKey));
             Assert.Equal(entryValue, data);
         }
@@ -993,7 +993,7 @@ namespace StackExchange.Redis.Extensions.Tests
             Assert.Equal(initialValue, data);
         }
 
-        [Fact] // TODO: NX doesn't work for some reason
+        [Fact]
         public async Task HashSetSingleValueAsync_ValueExists_ShouldUpdateValue()
         {
             // arrange
@@ -1004,11 +1004,11 @@ namespace StackExchange.Redis.Extensions.Tests
             var initRes = await Sut.Database.HashSetAsync(hashKey, entryKey, Serializer.Serialize(initialValue));
 
             // act
-            var res = await Sut.HashSetAsync(hashKey, entryKey, entryValue, true);
+            var res = await Sut.HashSetAsync(hashKey, entryKey, entryValue, nx: false);
 
             // assert
             Assert.True(initRes);
-            Assert.True(res);
+            Assert.False(res); // NOTE: HSET returns: 1 if new field was created and value set, or 0 if field existed and value set. reference: http://redis.io/commands/HSET
             var data = Serializer.Deserialize<TestClass<DateTime>>(await Sut.Database.HashGetAsync(hashKey, entryKey));
             Assert.Equal(entryValue, data);
         }

--- a/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
+++ b/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
@@ -1176,7 +1176,7 @@ namespace StackExchange.Redis.Extensions.Tests
             // arrange
             var hashKey = Guid.NewGuid().ToString();
             var values =
-                Enumerable.Range(0, 1000)
+                Range(0, 1000)
                     .Select(x => new TestClass<int>(Guid.NewGuid().ToString(), x))
                     .ToDictionary(x => x.Key);
 

--- a/tests/StackExchange.Redis.Extensions.Tests/Helpers/TestClass.cs
+++ b/tests/StackExchange.Redis.Extensions.Tests/Helpers/TestClass.cs
@@ -6,25 +6,68 @@
 // //////////////////////////////////////////////////////////////////////////////////////////////////
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace StackExchange.Redis.Extensions.Tests.Helpers
 {
 	[Serializable]
     [DataContract]
-	public class TestClass<T>
+	public class TestClass<T> : IEquatable<TestClass<T>>
 	{
+	    public TestClass()
+	    {
+	        
+	    }
+
+	    public TestClass(string key, T value)
+	    {
+	        Key = key;
+	        Value = value;
+	    }
+
         [DataMember(Order = 1)]
 		public string Key { get; set; }
 
         [DataMember(Order = 2)]
 		public T Value { get; set; }
+
+	    public override bool Equals(object other)
+	    {
+	        return Equals(other as TestClass<T>);
+	    }
+
+	    public bool Equals(TestClass<T> other)
+	    {
+	        if (ReferenceEquals(null, other)) return false;
+	        if (ReferenceEquals(this, other)) return true;
+	        return string.Equals(Key, other.Key) && EqualityComparer<T>.Default.Equals(Value, other.Value);
+	    }
+
+	    public override int GetHashCode()
+	    {
+	        unchecked
+	        {
+	            return ((Key?.GetHashCode() ?? 0)*397) ^ EqualityComparer<T>.Default.GetHashCode(Value);
+	        }
+	    }
+
+	    public static bool operator ==(TestClass<T> left, TestClass<T> right)
+	    {
+	        return Equals(left, right);
+	    }
+
+	    public static bool operator !=(TestClass<T> left, TestClass<T> right)
+	    {
+	        return !Equals(left, right);
+	    }
 	}
 
     [Serializable]
     [DataContract]
-	public class ComplexClassForTest<T,TK>
-	{
+	public class ComplexClassForTest<T,TK> : IEquatable<ComplexClassForTest<T, TK>>
+    {
 		public ComplexClassForTest()
 		{
 		}
@@ -40,5 +83,35 @@ namespace StackExchange.Redis.Extensions.Tests.Helpers
 
         [DataMember(Order = 2)]
 		public TK Item2 { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ComplexClassForTest<T, TK>);
+        }
+
+        public bool Equals(ComplexClassForTest<T, TK> other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return EqualityComparer<T>.Default.Equals(Item1, other.Item1) && EqualityComparer<TK>.Default.Equals(Item2, other.Item2);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (EqualityComparer<T>.Default.GetHashCode(Item1)*397) ^ EqualityComparer<TK>.Default.GetHashCode(Item2);
+            }
+        }
+
+        public static bool operator ==(ComplexClassForTest<T, TK> left, ComplexClassForTest<T, TK> right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(ComplexClassForTest<T, TK> left, ComplexClassForTest<T, TK> right)
+        {
+            return !Equals(left, right);
+        }
 	}
 }

--- a/tests/StackExchange.Redis.Extensions.Tests/Helpers/TestClass.cs
+++ b/tests/StackExchange.Redis.Extensions.Tests/Helpers/TestClass.cs
@@ -33,9 +33,9 @@ namespace StackExchange.Redis.Extensions.Tests.Helpers
         [DataMember(Order = 2)]
 		public T Value { get; set; }
 
-	    public override bool Equals(object other)
+	    public override bool Equals(object obj)
 	    {
-	        return Equals(other as TestClass<T>);
+	        return Equals(obj as TestClass<T>);
 	    }
 
 	    public bool Equals(TestClass<T> other)

--- a/tests/StackExchange.Redis.Extensions.Tests/StackExchange.Redis.Extensions.Tests.csproj
+++ b/tests/StackExchange.Redis.Extensions.Tests/StackExchange.Redis.Extensions.Tests.csproj
@@ -36,9 +36,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FizzWare.NBuilder">
-      <HintPath>..\..\packages\NBuilder.3.0.1.1\lib\FizzWare.NBuilder.dll</HintPath>
-    </Reference>
     <Reference Include="Jil, Version=2.12.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Jil.2.12.1\lib\net45\Jil.dll</HintPath>

--- a/tests/StackExchange.Redis.Extensions.Tests/packages.config
+++ b/tests/StackExchange.Redis.Extensions.Tests/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="Jil" version="2.12.1" targetFramework="net45" />
   <package id="MsgPack.Cli" version="0.6.2" targetFramework="net45" />
-  <package id="NBuilder" version="3.0.1.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="Sigil" version="4.5.0" targetFramework="net45" />
   <package id="StackExchange.Redis" version="1.0.481" targetFramework="net45" />


### PR DESCRIPTION
Added all [methods](http://redis.io/commands/#hash) to Hashes, except `HSTRLEN` which doesn't really make sense when serializing objects to redis. 

The include methods implement async API aswell as sync API.


**TODOs:**
* Documentations exists however it is not uniform with original documentation format
* No unit/integrations tests are provided with the code
* Might need some optimizations, especially the multi-get/set methods