### PR TITLE
Check for isConnected and feature support for SCAN before calling Keys

### DIFF
--- a/src/StackExchange.Redis.Extensions.Core/Configuration/IRedisCachingConfiguration.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Configuration/IRedisCachingConfiguration.cs
@@ -14,6 +14,11 @@
 		RedisHostCollection RedisHosts { get; }
 
 		/// <summary>
+		/// The strategy to use when executing server wide commands
+		/// </summary>
+		ServerEnumerationStrategy ServerEnumerationStrategy { get; }
+
+		/// <summary>
 		/// Specify if the connection can use Admin commands like flush database
 		/// </summary>
 		/// <value>

--- a/src/StackExchange.Redis.Extensions.Core/Configuration/RedisCachingSectionHandler.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Configuration/RedisCachingSectionHandler.cs
@@ -14,7 +14,16 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
 		/// The ip or name
 		/// </value>
 		[ConfigurationProperty("hosts")]
-		public RedisHostCollection RedisHosts => this["hosts"] as RedisHostCollection;
+		public RedisHostCollection RedisHosts
+			=> this["hosts"] as RedisHostCollection;
+
+		/// <summary>
+		/// The strategy to use when executing server wide commands
+		/// </summary>
+		[ConfigurationProperty("serverEnumerationStrategy")]
+		public ServerEnumerationStrategy ServerEnumerationStrategy
+			=> this["serverEnumerationStrategy"] as ServerEnumerationStrategy;
+		
 
 		/// <summary>
 		/// Specify if the connection can use Admin commands like flush database

--- a/src/StackExchange.Redis.Extensions.Core/Configuration/ServerEnumerationStrategy.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Configuration/ServerEnumerationStrategy.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Configuration;
+
+namespace StackExchange.Redis.Extensions.Core.Configuration
+{
+	public class ServerEnumerationStrategy : ConfigurationElement
+	{
+		public enum ModeOptions
+		{
+			All = 0,
+			Single
+		}
+
+		public enum TargetRoleOptions
+		{
+			Any = 0,
+			PreferSlave
+		}
+
+		public enum UnreachableServerActionOptions
+		{
+			Throw = 0,
+			Ignore
+		}
+
+		[ConfigurationProperty("mode", IsRequired = false, DefaultValue = "All")]
+		public ModeOptions Mode
+		{
+			get { return (ModeOptions)base["mode"]; }
+			set { base["mode"] = value; }
+		}
+
+		[ConfigurationProperty("targetRole", IsRequired = false, DefaultValue = "Any")]
+		public TargetRoleOptions TargetRole
+		{
+			get { return (TargetRoleOptions)base["targetRole"]; }
+			set { base["targetRole"] = value; }
+		}
+
+		[ConfigurationProperty("unreachableServerAction", IsRequired = false, DefaultValue = "Throw")]
+		public UnreachableServerActionOptions UnreachableServerAction
+		{
+			get { return (UnreachableServerActionOptions)base["unreachableServerAction"]; }
+			set { base["unreachableServerAction"] = value; }
+		}
+	}
+}

--- a/src/StackExchange.Redis.Extensions.Core/ServerIteration/ServerEnumerable.cs
+++ b/src/StackExchange.Redis.Extensions.Core/ServerIteration/ServerEnumerable.cs
@@ -34,7 +34,7 @@ namespace StackExchange.Redis.Extensions.Core.ServerIteration
 				}
 				if (unreachableServerAction == ServerEnumerationStrategy.UnreachableServerActionOptions.Ignore)
 				{
-					if (!server.IsConnected)
+					if (!server.IsConnected || !server.Features.Scan)
 						continue;
 				}
 

--- a/src/StackExchange.Redis.Extensions.Core/ServerIteration/ServerEnumerable.cs
+++ b/src/StackExchange.Redis.Extensions.Core/ServerIteration/ServerEnumerable.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Net;
+using StackExchange.Redis.Extensions.Core.Configuration;
+
+namespace StackExchange.Redis.Extensions.Core.ServerIteration
+{
+	public class ServerEnumerable : IEnumerable<IServer>
+	{
+		private readonly ConnectionMultiplexer multiplexer;
+		private readonly ServerEnumerationStrategy.TargetRoleOptions targetRole;
+		private readonly ServerEnumerationStrategy.UnreachableServerActionOptions unreachableServerAction;
+
+		public ServerEnumerable(
+			ConnectionMultiplexer multiplexer,
+			ServerEnumerationStrategy.TargetRoleOptions targetRole,
+			ServerEnumerationStrategy.UnreachableServerActionOptions unreachableServerAction)
+		{
+			this.multiplexer = multiplexer;
+			this.targetRole = targetRole;
+			this.unreachableServerAction = unreachableServerAction;
+		}
+
+		public IEnumerator<IServer> GetEnumerator()
+		{
+			foreach (var endPoint in multiplexer.GetEndPoints())
+			{
+				var server = multiplexer.GetServer(endPoint);
+				if (targetRole == ServerEnumerationStrategy.TargetRoleOptions.PreferSlave)
+				{
+					if (!server.IsSlave)
+						continue;
+				}
+				if (unreachableServerAction == ServerEnumerationStrategy.UnreachableServerActionOptions.Ignore)
+				{
+					if (!server.IsConnected)
+						continue;
+				}
+
+				yield return server;
+			}
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+	}
+}

--- a/src/StackExchange.Redis.Extensions.Core/ServerIteration/ServerIteratorFactory.cs
+++ b/src/StackExchange.Redis.Extensions.Core/ServerIteration/ServerIteratorFactory.cs
@@ -9,10 +9,8 @@ namespace StackExchange.Redis.Extensions.Core.ServerIteration
 	{
 		public static IEnumerable<IServer> GetServers(
 			ConnectionMultiplexer multiplexer,
-			ServerEnumerationStrategy serverEnumerationStrategy = null)
+			ServerEnumerationStrategy serverEnumerationStrategy)
 		{
-			serverEnumerationStrategy = serverEnumerationStrategy ?? new ServerEnumerationStrategy();
-
 			switch (serverEnumerationStrategy.Mode)
 			{
 				case ServerEnumerationStrategy.ModeOptions.All:

--- a/src/StackExchange.Redis.Extensions.Core/ServerIteration/ServerIteratorFactory.cs
+++ b/src/StackExchange.Redis.Extensions.Core/ServerIteration/ServerIteratorFactory.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using StackExchange.Redis.Extensions.Core.Configuration;
+
+namespace StackExchange.Redis.Extensions.Core.ServerIteration
+{
+	public class ServerIteratorFactory
+	{
+		public static IEnumerable<IServer> GetServers(
+			ConnectionMultiplexer multiplexer,
+			ServerEnumerationStrategy serverEnumerationStrategy)
+		{
+			switch (serverEnumerationStrategy.Mode)
+			{
+				case ServerEnumerationStrategy.ModeOptions.All:
+					var serversAll = new ServerEnumerable(multiplexer,
+						serverEnumerationStrategy.TargetRole,
+						serverEnumerationStrategy.UnreachableServerAction);
+					return serversAll;
+
+				case ServerEnumerationStrategy.ModeOptions.Single:
+					var serversSingle = new ServerEnumerable(multiplexer,
+						serverEnumerationStrategy.TargetRole,
+						serverEnumerationStrategy.UnreachableServerAction);
+					return serversSingle.Take(1);
+
+				default:
+					throw new NotImplementedException();
+			}
+		}
+	}
+}

--- a/src/StackExchange.Redis.Extensions.Core/ServerIteration/ServerIteratorFactory.cs
+++ b/src/StackExchange.Redis.Extensions.Core/ServerIteration/ServerIteratorFactory.cs
@@ -9,8 +9,10 @@ namespace StackExchange.Redis.Extensions.Core.ServerIteration
 	{
 		public static IEnumerable<IServer> GetServers(
 			ConnectionMultiplexer multiplexer,
-			ServerEnumerationStrategy serverEnumerationStrategy)
+			ServerEnumerationStrategy serverEnumerationStrategy = null)
 		{
+			serverEnumerationStrategy = serverEnumerationStrategy ?? new ServerEnumerationStrategy();
+
 			switch (serverEnumerationStrategy.Mode)
 			{
 				case ServerEnumerationStrategy.ModeOptions.All:

--- a/src/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.csproj
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.csproj
@@ -50,10 +50,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ServerIteration\ServerIteratorFactory.cs" />
+    <Compile Include="ServerIteration\ServerEnumerable.cs" />
     <Compile Include="Configuration\IRedisCachingConfiguration.cs" />
     <Compile Include="Configuration\RedisCachingSectionHandler.cs" />
     <Compile Include="Configuration\RedisHost.cs" />
     <Compile Include="Configuration\RedisHostCollection.cs" />
+    <Compile Include="Configuration\ServerEnumerationStrategy.cs" />
     <Compile Include="StackExchangeRedisCacheClient.cs" />
     <Compile Include="Extensions\LinqExtensions.cs" />
     <Compile Include="ICacheClient.cs" />

--- a/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
@@ -15,7 +15,7 @@ namespace StackExchange.Redis.Extensions.Core
 	public class StackExchangeRedisCacheClient : ICacheClient
 	{
 		private readonly ConnectionMultiplexer connectionMultiplexer;
-		private readonly ServerEnumerationStrategy serverEnumerationStrategy;
+		private readonly ServerEnumerationStrategy serverEnumerationStrategy = new ServerEnumerationStrategy();
 
 		/// <summary>
 		///     Initializes a new instance of the <see cref="StackExchangeRedisCacheClient" /> class.

--- a/tests/StackExchange.Redis.Extensions.Tests/App.config
+++ b/tests/StackExchange.Redis.Extensions.Tests/App.config
@@ -5,6 +5,7 @@
 	</configSections>
 
   <redisCacheClient allowAdmin="true" ssl="false" connectTimeout="5000" database="0">
+    <serverEnumerationStrategy mode="single" targetRole="preferSlave" unreachableServerAction="ignore" /> 
     <hosts>
       <add host="127.0.0.1" cachePort="6379" />
     </hosts>


### PR DESCRIPTION
An exception is thrown when a server becomes temporarily disconnected,
or when SCAN action is not supported. By adding these checks we are
allowing keys from other servers to be consumed.