### PR TITLE
Raise exception if failure is total when executing KEYS command.

### DIFF
--- a/src/StackExchange.Redis.Extensions.Core/Configuration/ServerEnumerationStrategy.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Configuration/ServerEnumerationStrategy.cs
@@ -20,7 +20,7 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
 		public enum UnreachableServerActionOptions
 		{
 			Throw = 0,
-			Ignore
+			IgnoreIfOtherAvailable
 		}
 
 		[ConfigurationProperty("mode", IsRequired = false, DefaultValue = "All")]

--- a/src/StackExchange.Redis.Extensions.Core/ServerIteration/ServerEnumerable.cs
+++ b/src/StackExchange.Redis.Extensions.Core/ServerIteration/ServerEnumerable.cs
@@ -32,7 +32,7 @@ namespace StackExchange.Redis.Extensions.Core.ServerIteration
 					if (!server.IsSlave)
 						continue;
 				}
-				if (unreachableServerAction == ServerEnumerationStrategy.UnreachableServerActionOptions.Ignore)
+				if (unreachableServerAction == ServerEnumerationStrategy.UnreachableServerActionOptions.IgnoreIfOtherAvailable)
 				{
 					if (!server.IsConnected || !server.Features.Scan)
 						continue;

--- a/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
@@ -632,7 +632,11 @@ namespace StackExchange.Redis.Extensions.Core
 			var keys = new HashSet<RedisKey>();
 
 			var multiplexer = Database.Multiplexer;
-			var servers = ServerIteratorFactory.GetServers(multiplexer, serverEnumerationStrategy);
+			var servers = ServerIteratorFactory.GetServers(multiplexer, serverEnumerationStrategy).ToArray();
+			if (!servers.Any())
+			{
+				throw new Exception("No server found to serve the KEYS command.");
+			}
 
 			foreach (var server in servers)
 			{


### PR DESCRIPTION
While thinking about the implementation i ran into this scenario: no active server to server the request. In the case where there is no server to serve the Keys we should (I believe) throw an exception even when the setting is set to Ignore. The Ignore is intended to ignore single failure, not total failure do you agree? If so here it is the PR.
I also changed the setting value from Ignore to IgnoreIfOtherAvailable to convey the intention.