### PR TITLE
Downgraded StackExchange.Redis package to lowest version that still compiles.

### DIFF
--- a/src/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.csproj
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.csproj
@@ -35,8 +35,8 @@
     </NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="StackExchange.Redis, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\StackExchange.Redis.1.2.0\lib\net45\StackExchange.Redis.dll</HintPath>
+    <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\StackExchange.Redis.1.0.479\lib\net45\StackExchange.Redis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.nuspec
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.nuspec
@@ -47,7 +47,7 @@
 		<language>en-US</language>
 		<tags>Async Redis NoSQL Client Distributed Cache PubSub Messaging</tags>
 		<dependencies>
-			<dependency id="StackExchange.Redis" version="1.2.0" />
+			<dependency id="StackExchange.Redis" version="1.0.479" />
 		</dependencies>
 	</metadata>
 </package>

--- a/src/StackExchange.Redis.Extensions.Core/packages.config
+++ b/src/StackExchange.Redis.Extensions.Core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StackExchange.Redis" version="1.2.0" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.0.479" targetFramework="net45" />
 </packages>

--- a/tests/StackExchange.Redis.Extensions.Tests/StackExchange.Redis.Extensions.Tests.csproj
+++ b/tests/StackExchange.Redis.Extensions.Tests/StackExchange.Redis.Extensions.Tests.csproj
@@ -53,9 +53,8 @@
       <HintPath>..\..\packages\Sigil.4.7.0\lib\net45\Sigil.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StackExchange.Redis, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\StackExchange.Redis.1.1.603\lib\net45\StackExchange.Redis.dll</HintPath>
+    <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\StackExchange.Redis.1.0.479\lib\net45\StackExchange.Redis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/tests/StackExchange.Redis.Extensions.Tests/packages.config
+++ b/tests/StackExchange.Redis.Extensions.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="MsgPack.Cli" version="0.8.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="Sigil" version="4.7.0" targetFramework="net45" />
-  <package id="StackExchange.Redis" version="1.1.603" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.0.479" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />


### PR DESCRIPTION
Implements part of issue #74 .
All tests still succeed. Couldn't downgrade further, because IConnectionMultiplexer (as a test abstraction) was introduced in 1.0.479.