### PR TITLE
Change RemoveAll to delete items in a single Redis call

### DIFF
--- a/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
@@ -226,7 +226,8 @@ namespace StackExchange.Redis.Extensions.Core
 		/// <param name="keys">The key.</param>
 		public void RemoveAll(IEnumerable<string> keys)
 		{
-			keys.ForEach(x => Remove(x));
+			var redisKeys = keys.Select(x => (RedisKey)x).ToArray();
+			Database.KeyDelete(redisKeys);
 		}
 
 		/// <summary>
@@ -236,7 +237,8 @@ namespace StackExchange.Redis.Extensions.Core
 		/// <returns></returns>
 		public Task RemoveAllAsync(IEnumerable<string> keys)
 		{
-			return keys.ForEachAsync(RemoveAsync);
+			var redisKeys = keys.Select(x => (RedisKey)x).ToArray();
+			return Database.KeyDeleteAsync(redisKeys);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This fixes https://github.com/imperugo/StackExchange.Redis.Extensions/issues/97, where calls to bulk-delete Redis keys were unexpectedly executing many calls to Redis.