### PR TITLE
Switched from StackExchange.Redis to StackExchange.Redis.StrongName

### DIFF
--- a/src/StackExchange.Redis.Extensions.Core/Properties/AssemblyInfo.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Properties/AssemblyInfo.cs
@@ -34,6 +34,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.2.0")]
-[assembly: AssemblyFileVersion("2.2.0")]
+[assembly: AssemblyVersion("2.2.1")]
+[assembly: AssemblyFileVersion("2.2.1")]
 

--- a/src/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.csproj
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.csproj
@@ -35,8 +35,8 @@
     </NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="StackExchange.Redis, Version=1.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\StackExchange.Redis.1.2.3\lib\net45\StackExchange.Redis.dll</HintPath>
+    <Reference Include="StackExchange.Redis.StrongName, Version=1.2.4.0, Culture=neutral, PublicKeyToken=c219ff1ca8c2ce46, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\StackExchange.Redis.StrongName.1.2.4\lib\net45\StackExchange.Redis.StrongName.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.nuspec
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.nuspec
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
 	<metadata>
-		<id>StackExchange.Redis.Extensions.Core</id>
-		<title>StackExchange.Redis.Extensions.Core</title>
+		<id>StackExchange.Redis.Extensions.Core.StrongName</id>
+		<title>StackExchange.Redis.Extensions.Core.StrongName</title>
 		<version>$version$</version>
 		<authors>$author$</authors>
 		<owners>$author$</owners>
@@ -47,7 +47,7 @@
 		<language>en-US</language>
 		<tags>Async Redis NoSQL Client Distributed Cache PubSub Messaging</tags>
 		<dependencies>
-			<dependency id="StackExchange.Redis" version="1.2.3" />
+			<dependency id="StackExchange.Redis.StrongName" version="1.2.4" />
 		</dependencies>
 	</metadata>
 </package>

--- a/src/StackExchange.Redis.Extensions.Core/packages.config
+++ b/src/StackExchange.Redis.Extensions.Core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StackExchange.Redis" version="1.2.3" targetFramework="net45" />
+  <package id="StackExchange.Redis.StrongName" version="1.2.4" targetFramework="net45" />
 </packages>

--- a/tests/StackExchange.Redis.Extensions.Tests/StackExchange.Redis.Extensions.Tests.csproj
+++ b/tests/StackExchange.Redis.Extensions.Tests/StackExchange.Redis.Extensions.Tests.csproj
@@ -53,14 +53,13 @@
       <HintPath>..\..\packages\Sigil.4.7.0\lib\net45\Sigil.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StackExchange.Redis, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\StackExchange.Redis.1.1.603\lib\net45\StackExchange.Redis.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="StackExchange.Redis.StrongName, Version=1.2.4.0, Culture=neutral, PublicKeyToken=c219ff1ca8c2ce46, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\StackExchange.Redis.StrongName.1.2.4\lib\net45\StackExchange.Redis.StrongName.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/tests/StackExchange.Redis.Extensions.Tests/packages.config
+++ b/tests/StackExchange.Redis.Extensions.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="MsgPack.Cli" version="0.8.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="Sigil" version="4.7.0" targetFramework="net45" />
-  <package id="StackExchange.Redis" version="1.1.603" targetFramework="net45" />
+  <package id="StackExchange.Redis.StrongName" version="1.2.4" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />


### PR DESCRIPTION
There is a conflict with Microsoft.AspNet.SignalR.Redis Assembly. Microsoft is using strong signed assembly of StackExchange.Redis. 