### PR TITLE
Adding overloads to Get and GetAll to allow for sliding window

### DIFF
--- a/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/ICacheClient.cs
@@ -68,22 +68,60 @@ namespace StackExchange.Redis.Extensions.Core
 		/// <returns>Null if not present, otherwise the instance of T.</returns>
 		T Get<T>(string key);
 
-		/// <summary>
-		/// Get the object with the specified key from Redis database
-		/// </summary>
-		/// <typeparam name="T">The type of the expected object</typeparam>
-		/// <param name="key">The cache key.</param>
-		/// <returns>Null if not present, otherwise the instance of T.</returns>
-		Task<T> GetAsync<T>(string key);
+        /// <summary>
+        /// Get the object with the specified key from Redis database and update the expiry time
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="key">The cache key.</param>
+        /// <param name="expiresAt">Expiration time.</param>
+        /// <returns>Null if not present, otherwise the instance of T.</returns>
+        T Get<T>(string key, DateTimeOffset expiresAt);
 
-		/// <summary>
-		/// Adds the specified instance to the Redis database.
-		/// </summary>
-		/// <typeparam name="T">The type of the class to add to Redis</typeparam>
-		/// <param name="key">The cache key.</param>
-		/// <param name="value">The instance of T.</param>
-		/// <returns>True if the object has been added. Otherwise false</returns>
-		bool Add<T>(string key, T value);
+        /// <summary>
+        ///     Get the object with the specified key from Redis database and update the expiry time
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="key">The cache key.</param>
+        /// <param name="expiresIn">Time till the object expires.</param>
+        /// <returns>
+        ///     Null if not present, otherwise the instance of T.
+        /// </returns>
+        T Get<T>(string key, TimeSpan expiresIn);
+
+        /// <summary>
+        /// Get the object with the specified key from Redis database
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="key">The cache key.</param>
+        /// <returns>Null if not present, otherwise the instance of T.</returns>
+        Task<T> GetAsync<T>(string key);
+
+        /// <summary>Get the object with the specified key from Redis database and update the expiry time</summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="key">The cache key.</param>
+        /// <param name="expiresAt">Expiration time.</param>
+        /// <returns>Null if not present, otherwise the instance of T.</returns>
+        Task<T> GetAsync<T>(string key, DateTimeOffset expiresAt);
+
+        /// <summary>
+        ///     Get the object with the specified key from Redis database and update the expiry time
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="key">The cache key.</param>
+        /// <param name="expiresIn">Time till the object expires.</param>
+        /// <returns>
+        ///     Null if not present, otherwise the instance of T.
+        /// </returns>
+        Task<T> GetAsync<T>(string key, TimeSpan expiresIn);
+
+        /// <summary>
+        /// Adds the specified instance to the Redis database.
+        /// </summary>
+        /// <typeparam name="T">The type of the class to add to Redis</typeparam>
+        /// <param name="key">The cache key.</param>
+        /// <param name="value">The instance of T.</param>
+        /// <returns>True if the object has been added. Otherwise false</returns>
+        bool Add<T>(string key, T value);
 
 		/// <summary>
 		/// Adds the specified instance to the Redis database.
@@ -223,16 +261,64 @@ namespace StackExchange.Redis.Extensions.Core
 		/// </returns>
 		IDictionary<string, T> GetAll<T>(IEnumerable<string> keys);
 
-		/// <summary>
-		/// Get the objects with the specified keys from Redis database with a single roundtrip
-		/// </summary>
-		/// <typeparam name="T">The type of the expected object</typeparam>
-		/// <param name="keys">The keys.</param>
-		/// <returns>
-		/// Empty list if there are no results, otherwise the instance of T.
-		/// If a cache key is not present on Redis the specified object into the returned Dictionary will be null
-		/// </returns>
-		Task<IDictionary<string, T>> GetAllAsync<T>(IEnumerable<string> keys);
+        /// <summary>
+        ///     Get the objects with the specified keys from Redis database with one roundtrip
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="keys">The keys.</param>
+        /// <param name="expiresAt">Expiration time.</param>
+        /// <returns>
+        ///     Empty list if there are no results, otherwise the instance of T.
+        ///     If a cache key is not present on Redis the specified object into the returned Dictionary will be null
+        /// </returns>
+        IDictionary<string, T> GetAll<T>(IEnumerable<string> keys, DateTimeOffset expiresAt);
+
+        /// <summary>
+        ///     Get the objects with the specified keys from Redis database with one roundtrip
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="keys">The keys.</param>
+        /// <param name="expiresIn">Time until expiration.</param>
+        /// <returns>
+        ///     Empty list if there are no results, otherwise the instance of T.
+        ///     If a cache key is not present on Redis the specified object into the returned Dictionary will be null
+        /// </returns>
+        IDictionary<string, T> GetAll<T>(IEnumerable<string> keys, TimeSpan expiresIn);
+
+        /// <summary>
+        /// Get the objects with the specified keys from Redis database with a single roundtrip
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="keys">The keys.</param>
+        /// <returns>
+        /// Empty list if there are no results, otherwise the instance of T.
+        /// If a cache key is not present on Redis the specified object into the returned Dictionary will be null
+        /// </returns>
+        Task<IDictionary<string, T>> GetAllAsync<T>(IEnumerable<string> keys);
+
+        /// <summary>
+        ///     Get the objects with the specified keys from Redis database with one roundtrip
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="keys">The keys.</param>
+        /// <param name="expiresAt">Expiration time.</param>
+        /// <returns>
+        ///     Empty list if there are no results, otherwise the instance of T.
+        ///     If a cache key is not present on Redis the specified object into the returned Dictionary will be null
+        /// </returns>
+        Task<IDictionary<string, T>> GetAllAsync<T>(IEnumerable<string> keys, DateTimeOffset expiresAt);
+
+        /// <summary>
+        ///     Get the objects with the specified keys from Redis database with one roundtrip
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="keys">The keys.</param>
+        /// <param name="expiresIn">Time until expiration.</param>
+        /// <returns>
+        ///     Empty list if there are no results, otherwise the instance of T.
+        ///     If a cache key is not present on Redis the specified object into the returned Dictionary will be null
+        /// </returns>
+        Task<IDictionary<string, T>> GetAllAsync<T>(IEnumerable<string> keys, TimeSpan expiresIn);
 
         /// <summary>
         /// Add the objects with the specified keys to Redis database with a single roundtrip
@@ -909,5 +995,69 @@ namespace StackExchange.Redis.Extensions.Core
 		/// <param name="commandFlags">Command execution flags</param>
 		/// <returns></returns> 
 		Task<Dictionary<string, T>> HashScanAsync<T>(string hashKey, string pattern, int pageSize = 10, CommandFlags commandFlags = CommandFlags.None);
-	}
+
+        /// <summary>
+        /// Updates the expiry time of a redis cache object
+        /// </summary>
+        /// <param name="key">The key of the object</param>
+        /// <param name="expiresAt">The new expiry time of the object</param>
+        /// <returns>True if the object is updated, false if the object does not exist</returns>
+        bool UpdateExpiry(string key, DateTimeOffset expiresAt);
+
+        /// <summary>
+        /// Updates the expiry time of a redis cache object
+        /// </summary>
+        /// <param name="key">The key of the object</param>
+        /// <param name="expiresIn">Time until the object will expire</param>
+        /// <returns>True if the object is updated, false if the object does not exist</returns>
+        bool UpdateExpiry(string key, TimeSpan expiresIn);
+
+        /// <summary>
+        /// Updates the expiry time of a redis cache object
+        /// </summary>
+        /// <param name="key">The key of the object</param>
+        /// <param name="expiresAt">The new expiry time of the object</param>
+        /// <returns>True if the object is updated, false if the object does not exist</returns>
+        Task<bool> UpdateExpiryAsync(string key, DateTimeOffset expiresAt);
+
+        /// <summary>
+        /// Updates the expiry time of a redis cache object
+        /// </summary>
+        /// <param name="key">The key of the object</param>
+        /// <param name="expiresIn">Time until the object will expire</param>
+        /// <returns>True if the object is updated, false if the object does not exist</returns>
+        Task<bool> UpdateExpiryAsync(string key, TimeSpan expiresIn);
+
+        /// <summary>
+        /// Updates the expiry time of a redis cache object
+        /// </summary>
+        /// <param name="keys">An array of keys to be updated</param>
+        /// <param name="expiresAt">The new expiry time of the object</param>
+        /// <returns>An array of type bool, where true if the object is updated and false if the object does not exist at the same index as the input keys</returns>
+        IDictionary<string, bool> UpdateExpiryAll(string[] keys, DateTimeOffset expiresAt);
+
+        /// <summary>
+        /// Updates the expiry time of a redis cache object
+        /// </summary>
+        /// <param name="keys">An array of keys to be updated</param>
+        /// <param name="expiresIn">Time until the object will expire</param>
+        /// <returns>An IDictionary object that contains the origional key and the result of the operation</returns>
+        IDictionary<string, bool> UpdateExpiryAll(string[] keys, TimeSpan expiresIn);
+
+        /// <summary>
+        /// Updates the expiry time of a redis cache object
+        /// </summary>
+        /// <param name="keys">An array of keys to be updated</param>
+        /// <param name="expiresAt">The new expiry time of the object</param>
+        /// <returns>An array of type bool, where true if the object is updated and false if the object does not exist at the same index as the input keys</returns>
+        Task<IDictionary<string, bool>> UpdateExpiryAllAsync(string[] keys, DateTimeOffset expiresAt);
+
+        /// <summary>
+        /// Updates the expiry time of a redis cache object
+        /// </summary>
+        /// <param name="keys">An array of keys to be updated</param>
+        /// <param name="expiresIn">Time until the object will expire</param>
+        /// <returns>An IDictionary object that contains the origional key and the result of the operation</returns>
+        Task<IDictionary<string, bool>> UpdateExpiryAllAsync(string[] keys, TimeSpan expiresIn);
+    }
 }

--- a/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
@@ -279,15 +279,57 @@ namespace StackExchange.Redis.Extensions.Core
 			return Serializer.Deserialize<T>(valueBytes);
 		}
 
-		/// <summary>
-		///     Get the object with the specified key from Redis database
-		/// </summary>
-		/// <typeparam name="T">The type of the expected object</typeparam>
-		/// <param name="key">The cache key.</param>
-		/// <returns>
-		///     Null if not present, otherwise the instance of T.
-		/// </returns>
-		public async Task<T> GetAsync<T>(string key)
+        /// <summary>
+        ///     Get the object with the specified key from Redis database and update the expiry time
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="key">The cache key.</param>
+        /// <param name="expiresAt">Expiration time.</param>
+        /// <returns>
+        ///     Null if not present, otherwise the instance of T.
+        /// </returns>
+        public T Get<T>(string key, DateTimeOffset expiresAt)
+        {
+            var result = Get<T>(key);
+            
+            if (!Equals(result, default(T)))
+            {
+                Database.KeyExpire(key, expiresAt.Subtract(DateTime.Now));
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        ///     Get the object with the specified key from Redis database and update the expiry time
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="key">The cache key.</param>
+        /// <param name="expiresIn">Time till the object expires.</param>
+        /// <returns>
+        ///     Null if not present, otherwise the instance of T.
+        /// </returns>
+        public T Get<T>(string key, TimeSpan expiresIn)
+        {
+            var result = Get<T>(key);
+
+            if (!Equals(result, default(T)))
+            {
+                Database.KeyExpire(key, expiresIn);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        ///     Get the object with the specified key from Redis database
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="key">The cache key.</param>
+        /// <returns>
+        ///     Null if not present, otherwise the instance of T.
+        /// </returns>
+        public async Task<T> GetAsync<T>(string key)
 		{
 			var valueBytes = await Database.StringGetAsync(key);
 
@@ -299,16 +341,58 @@ namespace StackExchange.Redis.Extensions.Core
 			return await Serializer.DeserializeAsync<T>(valueBytes);
 		}
 
-		/// <summary>
-		///     Adds the specified instance to the Redis database.
-		/// </summary>
-		/// <typeparam name="T">The type of the class to add to Redis</typeparam>
-		/// <param name="key">The cache key.</param>
-		/// <param name="value">The instance of T.</param>
-		/// <returns>
-		///     True if the object has been added. Otherwise false
-		/// </returns>
-		public bool Add<T>(string key, T value)
+        /// <summary>
+        ///     Get the object with the specified key from Redis database and update the expiry time
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="key">The cache key.</param>
+        /// <param name="expiresAt">Expiration time.</param>
+        /// <returns>
+        ///     Null if not present, otherwise the instance of T.
+        /// </returns>
+        public async Task<T> GetAsync<T>(string key, DateTimeOffset expiresAt)
+        {
+            var result = await GetAsync<T>(key);
+
+            if (!Equals(result, default(T)))
+            {
+                await Database.KeyExpireAsync(key, expiresAt.Subtract(DateTime.Now));
+            }
+
+            return default(T);
+        }
+
+        /// <summary>
+        ///     Get the object with the specified key from Redis database and update the expiry time
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="key">The cache key.</param>
+        /// <param name="expiresIn">Time till the object expires.</param>
+        /// <returns>
+        ///     Null if not present, otherwise the instance of T.
+        /// </returns>
+        public async Task<T> GetAsync<T>(string key, TimeSpan expiresIn)
+        {
+            var result = await GetAsync<T>(key);
+
+            if (!Equals(result, default(T)))
+            {
+                await Database.KeyExpireAsync(key, expiresIn);
+            }
+
+            return default(T);
+        }
+
+        /// <summary>
+        ///     Adds the specified instance to the Redis database.
+        /// </summary>
+        /// <typeparam name="T">The type of the class to add to Redis</typeparam>
+        /// <param name="key">The cache key.</param>
+        /// <param name="value">The instance of T.</param>
+        /// <returns>
+        ///     True if the object has been added. Otherwise false
+        /// </returns>
+        public bool Add<T>(string key, T value)
 		{
 			var entryBytes = Serializer.Serialize(value);
 
@@ -513,16 +597,50 @@ namespace StackExchange.Redis.Extensions.Core
 			return dict;
 		}
 
-		/// <summary>
-		///     Get the objects with the specified keys from Redis database with one roundtrip
-		/// </summary>
-		/// <typeparam name="T">The type of the expected object</typeparam>
-		/// <param name="keys">The keys.</param>
-		/// <returns>
-		///     Empty list if there are no results, otherwise the instance of T.
-		///     If a cache key is not present on Redis the specified object into the returned Dictionary will be null
-		/// </returns>
-		public async Task<IDictionary<string, T>> GetAllAsync<T>(IEnumerable<string> keys)
+        /// <summary>
+        ///     Get the objects with the specified keys from Redis database with one roundtrip
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="keys">The keys.</param>
+        /// <param name="expiresAt">Expiration time.</param>
+        /// <returns>
+        ///     Empty list if there are no results, otherwise the instance of T.
+        ///     If a cache key is not present on Redis the specified object into the returned Dictionary will be null
+        /// </returns>
+        public IDictionary<string, T> GetAll<T>(IEnumerable<string> keys, DateTimeOffset expiresAt)
+        {
+            var result = GetAll<T>(keys);
+            UpdateExpiryAll(keys.ToArray(), expiresAt);
+            return result;
+        }
+
+        /// <summary>
+        ///     Get the objects with the specified keys from Redis database with one roundtrip
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="keys">The keys.</param>
+        /// <param name="expiresIn">Time until expiration.</param>
+        /// <returns>
+        ///     Empty list if there are no results, otherwise the instance of T.
+        ///     If a cache key is not present on Redis the specified object into the returned Dictionary will be null
+        /// </returns>
+        public IDictionary<string, T> GetAll<T>(IEnumerable<string> keys, TimeSpan expiresIn)
+        {
+            var result = GetAll<T>(keys);
+            UpdateExpiryAll(keys.ToArray(), expiresIn);
+            return result;
+        }
+
+        /// <summary>
+        ///     Get the objects with the specified keys from Redis database with one roundtrip
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="keys">The keys.</param>
+        /// <returns>
+        ///     Empty list if there are no results, otherwise the instance of T.
+        ///     If a cache key is not present on Redis the specified object into the returned Dictionary will be null
+        /// </returns>
+        public async Task<IDictionary<string, T>> GetAllAsync<T>(IEnumerable<string> keys)
 		{
 			var redisKeys = keys.Select(x => (RedisKey)x).ToArray();
 			var result = await Database.StringGetAsync(redisKeys);
@@ -533,6 +651,40 @@ namespace StackExchange.Redis.Extensions.Core
 				dict.Add(redisKeys[index], value == RedisValue.Null ? default(T) : Serializer.Deserialize<T>(value));
 			}
 			return dict;
+        }
+
+        /// <summary>
+        ///     Get the objects with the specified keys from Redis database with one roundtrip
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="keys">The keys.</param>
+        /// <param name="expiresAt">Expiration time.</param>
+        /// <returns>
+        ///     Empty list if there are no results, otherwise the instance of T.
+        ///     If a cache key is not present on Redis the specified object into the returned Dictionary will be null
+        /// </returns>
+        public async Task<IDictionary<string, T>> GetAllAsync<T>(IEnumerable<string> keys, DateTimeOffset expiresAt)
+        {
+            var result = await GetAllAsync<T>(keys);
+            await UpdateExpiryAllAsync(keys.ToArray(), expiresAt);
+            return result;
+        }
+
+        /// <summary>
+        ///     Get the objects with the specified keys from Redis database with one roundtrip
+        /// </summary>
+        /// <typeparam name="T">The type of the expected object</typeparam>
+        /// <param name="keys">The keys.</param>
+        /// <param name="expiresIn">Time until expiration.</param>
+        /// <returns>
+        ///     Empty list if there are no results, otherwise the instance of T.
+        ///     If a cache key is not present on Redis the specified object into the returned Dictionary will be null
+        /// </returns>
+        public async Task<IDictionary<string, T>> GetAllAsync<T>(IEnumerable<string> keys, TimeSpan expiresIn)
+        {
+            var result = await GetAllAsync<T>(keys);
+            await UpdateExpiryAllAsync(keys.ToArray(), expiresIn);
+            return result;
         }
 
         /// <summary>
@@ -1780,5 +1932,133 @@ namespace StackExchange.Redis.Extensions.Core
 			return (await Task.Run(() => Database.HashScan(hashKey, pattern, pageSize, commandFlags)))
 				.ToDictionary(x => x.Name.ToString(), x => Serializer.Deserialize<T>(x.Value), StringComparer.Ordinal);
 		}
-	}
+
+        /// <summary>
+        /// Updates the expiry time of a redis cache object
+        /// </summary>
+        /// <param name="key">The key of the object</param>
+        /// <param name="expiresAt">The new expiry time of the object</param>
+        /// <returns>True if the object is updated, false if the object does not exist</returns>
+        public bool UpdateExpiry(string key, DateTimeOffset expiresAt)
+        {
+            if (Database.KeyExists(key))
+            {
+                return Database.KeyExpire(key, expiresAt.Subtract(DateTime.Now));
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Updates the expiry time of a redis cache object
+        /// </summary>
+        /// <param name="key">The key of the object</param>
+        /// <param name="expiresIn">Time until the object will expire</param>
+        /// <returns>True if the object is updated, false if the object does not exist</returns>
+        public bool UpdateExpiry(string key, TimeSpan expiresIn)
+        {
+            if (Database.KeyExists(key))
+            {
+                return Database.KeyExpire(key, expiresIn);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Updates the expiry time of a redis cache object
+        /// </summary>
+        /// <param name="key">The key of the object</param>
+        /// <param name="expiresAt">The new expiry time of the object</param>
+        /// <returns>True if the object is updated, false if the object does not exist</returns>
+        public async Task<bool> UpdateExpiryAsync(string key, DateTimeOffset expiresAt)
+        {
+            if (await Database.KeyExistsAsync(key))
+            {
+                return await Database.KeyExpireAsync(key, expiresAt.Subtract(DateTime.Now));
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Updates the expiry time of a redis cache object
+        /// </summary>
+        /// <param name="key">The key of the object</param>
+        /// <param name="expiresIn">Time until the object will expire</param>
+        /// <returns>True if the object is updated, false if the object does not exist</returns>
+        public async Task<bool> UpdateExpiryAsync(string key, TimeSpan expiresIn)
+        {
+            if (await Database.KeyExistsAsync(key))
+            {
+                return await Database.KeyExpireAsync(key, expiresIn);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Updates the expiry time of a redis cache object
+        /// </summary>
+        /// <param name="keys">An array of keys to be updated</param>
+        /// <param name="expiresAt">The new expiry time of the object</param>
+        /// <returns>An IDictionary object that contains the origional key and the result of the operation</returns>
+        public IDictionary<string, bool> UpdateExpiryAll(string[] keys, DateTimeOffset expiresAt)
+        {
+            var results = new Dictionary<string, bool>(StringComparer.Ordinal);
+            for (int i = 0; i < keys.Length; i++)
+            {
+                results.Add(keys[i], UpdateExpiry(keys[i], expiresAt));
+            }
+            return results;
+        }
+
+        /// <summary>
+        /// Updates the expiry time of a redis cache object
+        /// </summary>
+        /// <param name="keys">An array of keys to be updated</param>
+        /// <param name="expiresIn">Time until the object will expire</param>
+        /// <returns>An IDictionary object that contains the origional key and the result of the operation</returns>
+        public IDictionary<string, bool> UpdateExpiryAll(string[] keys, TimeSpan expiresIn)
+        {
+            var results = new Dictionary<string, bool>(StringComparer.Ordinal);
+            for (int i = 0; i < keys.Length; i++)
+            {
+                results.Add(keys[i], UpdateExpiry(keys[i], expiresIn));
+            }
+            return results;
+        }
+
+        /// <summary>
+        /// Updates the expiry time of a redis cache object
+        /// </summary>
+        /// <param name="keys">An array of keys to be updated</param>
+        /// <param name="expiresAt">The new expiry time of the object</param>
+        /// <returns>An IDictionary object that contains the origional key and the result of the operation</returns>
+        public async Task<IDictionary<string, bool>> UpdateExpiryAllAsync(string[] keys, DateTimeOffset expiresAt)
+        {
+            var results = new Dictionary<string, bool>(StringComparer.Ordinal);
+            for (int i = 0; i < keys.Length; i++)
+            {
+                results.Add(keys[i], await UpdateExpiryAsync(keys[i], expiresAt));
+            }
+            return results;
+        }
+
+        /// <summary>
+        /// Updates the expiry time of a redis cache object
+        /// </summary>
+        /// <param name="keys">An array of keys to be updated</param>
+        /// <param name="expiresIn">Time until the object will expire</param>
+        /// <returns>An IDictionary object that contains the origional key and the result of the operation</returns>
+        public async Task<IDictionary<string, bool>> UpdateExpiryAllAsync(string[] keys, TimeSpan expiresIn)
+        {
+            var results = new Dictionary<string, bool>(StringComparer.Ordinal);
+            for (int i = 0; i < keys.Length; i++)
+            {
+                results.Add(keys[i], await UpdateExpiryAsync(keys[i], expiresIn));
+            }
+            return results;
+        }
+    }
 }

--- a/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
+++ b/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
@@ -704,6 +704,164 @@ namespace StackExchange.Redis.Extensions.Tests
             Assert.Equal(item, null);
         }
 
+        [Fact]
+        public void Get_Value_With_Expiry_Updates_ExpiryAt()
+        {
+            var key = "TestKey";
+            var value = "TestValue";
+            var originalTime = DateTime.UtcNow.AddSeconds(5);
+            var testTime = DateTime.UtcNow.AddSeconds(20);
+            var resultTimeSpan = originalTime.Subtract(DateTime.UtcNow);
+
+            Sut.Add(key, value, originalTime);
+            Sut.Get<string>(key, testTime);
+            var resultValue = Db.StringGetWithExpiry(key);
+
+            Assert.True(resultTimeSpan < resultValue.Expiry.Value);
+        }
+
+        [Fact]
+        public void Get_Value_With_Expiry_Updates_ExpiryIn()
+        {
+            var key = "TestKey";
+            var value = "TestValue";
+            var originalTime = new TimeSpan(0, 0, 5);
+            var testTime = new TimeSpan(0, 0, 20);
+            var resultTimeSpan = originalTime;
+
+            Sut.Add(key, value, originalTime);
+            Sut.Get<string>(key, testTime);
+            var resultValue = Db.StringGetWithExpiry(key);
+
+            Assert.True(resultTimeSpan < resultValue.Expiry.Value);
+        }
+
+        [Fact]
+        public async void Get_Value_With_Expiry_Updates_ExpiryAt_Async()
+        {
+            var key = "TestKey";
+            var value = "TestValue";
+            var originalTime = DateTime.UtcNow.AddSeconds(5);
+            var testTime = DateTime.UtcNow.AddSeconds(20);
+
+            await Sut.AddAsync(key, value, originalTime);
+            await Sut.GetAsync<string>(key, testTime);
+            var resultValue = Db.StringGetWithExpiry(key);
+
+            Assert.True(originalTime.Subtract(DateTime.UtcNow) < resultValue.Expiry.Value);
+        }
+
+        [Fact]
+        public async void Get_Value_With_Expiry_Updates_ExpiryIn_Async()
+        {
+            var key = "TestKey";
+            var value = "TestValue";
+            var originalTime = DateTime.UtcNow.AddSeconds(5).Subtract(DateTime.UtcNow);
+            var testTime = DateTime.UtcNow.AddSeconds(20).Subtract(DateTime.UtcNow);
+
+            await Sut.AddAsync(key, value, originalTime);
+            await Sut.GetAsync<string>(key, testTime);
+            var resultValue = Db.StringGetWithExpiry(key);
+
+            Assert.True(originalTime < resultValue.Expiry.Value);
+        }
+
+        [Fact]
+        public void Get_All_Value_With_Expiry_Updates_Expiry()
+        {
+            var key = "TestKey";
+            var value = new TestClass<string> { Key = key, Value = "Hello World!" };
+            var originalTime = DateTime.UtcNow.AddSeconds(5).Subtract(DateTime.UtcNow);
+            var testTime = DateTime.UtcNow.AddSeconds(20).Subtract(DateTime.UtcNow);
+
+            var values = new List<Tuple<string, TestClass<string>>>() { new Tuple<string, TestClass<string>>(key, value) };
+            var keys = new List<string> { key };
+
+            Sut.AddAll(values, originalTime);
+            Sut.GetAll<TestClass<string>>(keys, testTime);
+            var resultValue = Db.StringGetWithExpiry(key);
+
+            Assert.True(originalTime < resultValue.Expiry.Value);
+        }
+
+        [Fact]
+        public async void Get_All_Value_With_Expiry_Updates_Expiry_Async()
+        {
+            var key = "TestKey";
+            var value = new TestClass<string> { Key = key, Value = "Hello World!" };
+            var originalTime = DateTime.UtcNow.AddSeconds(5).Subtract(DateTime.UtcNow);
+            var testTime = DateTime.UtcNow.AddSeconds(20).Subtract(DateTime.UtcNow);
+
+            var values = new List<Tuple<string, TestClass<string>>>() { new Tuple<string, TestClass<string>>(key, value) };
+            var keys = new List<string> { key };
+
+            await Sut.AddAllAsync(values, originalTime);
+            await Sut.GetAllAsync<TestClass<string>>(keys, testTime);
+            var resultValue = Db.StringGetWithExpiry(key);
+
+            Assert.True(originalTime < resultValue.Expiry.Value);
+        }
+
+        [Fact]
+        public void Update_Expiry_ExpiresIn()
+        {
+            var key = "TestKey";
+            var value = "Test Value";
+            var originalTime = DateTime.UtcNow.AddSeconds(5).Subtract(DateTime.UtcNow);
+            var testTime = DateTime.UtcNow.AddSeconds(20).Subtract(DateTime.UtcNow);
+
+            Sut.Add(key, value, originalTime);
+            Sut.UpdateExpiry(key, testTime);
+
+            var resultValue = Db.StringGetWithExpiry(key);
+            Assert.True(originalTime < resultValue.Expiry.Value);
+        }
+
+        [Fact]
+        public async void Update_Expiry_ExpiresIn_Async()
+        {
+            var key = "TestKey";
+            var value = "Test Value";
+            var originalTime = DateTime.UtcNow.AddSeconds(5).Subtract(DateTime.UtcNow);
+            var testTime = DateTime.UtcNow.AddSeconds(20).Subtract(DateTime.UtcNow);
+
+            await Sut.AddAsync(key, value, originalTime);
+            await Sut.UpdateExpiryAsync(key, testTime);
+
+            var resultValue = Db.StringGetWithExpiry(key);
+            Assert.True(originalTime < resultValue.Expiry.Value);
+        }
+
+        [Fact]
+        public void Update_Expiry_ExpiresAt()
+        {
+            var key = "TestKey";
+            var value = "Test Value";
+            var originalTime = DateTime.UtcNow.AddSeconds(5);
+            var testTime = DateTime.UtcNow.AddSeconds(20);
+
+            Sut.Add(key, value, originalTime);
+            Sut.UpdateExpiry(key, testTime);
+
+            var resultValue = Db.StringGetWithExpiry(key);
+            Assert.True(originalTime.Subtract(DateTime.UtcNow) < resultValue.Expiry.Value);
+        }
+
+        [Fact]
+        public async void Update_Expiry_ExpiresAt_Async()
+        {
+            var key = "TestKey";
+            var value = "Test Value";
+            var originalTime = DateTime.UtcNow.AddSeconds(5);
+            var testTime = DateTime.UtcNow.AddSeconds(20);
+
+            await Sut.AddAsync(key, value, originalTime);
+            await Sut.UpdateExpiryAsync(key, testTime);
+
+            var resultValue = Db.StringGetWithExpiry(key);
+            Assert.True(originalTime.Subtract(DateTime.UtcNow) < resultValue.Expiry.Value);
+        }
+
         #region Hash tests
 
         [Fact]


### PR DESCRIPTION
Added overloads to Get and GetAll methods to allow for a sliding window (see #112 ), as well as adding methods to allow for the updating of expiry times without calling underlying database directly and all related unit tests.

