### PR TITLE
:bug: RedisCachingSectionHandler should map SSL setting

### DIFF
--- a/src/StackExchange.Redis.Extensions.LegacyConfiguration/RedisCachingSectionHandler.cs
+++ b/src/StackExchange.Redis.Extensions.LegacyConfiguration/RedisCachingSectionHandler.cs
@@ -146,6 +146,7 @@ namespace StackExchange.Redis.Extensions.LegacyConfiguration
 	        result.Database = cfg.Database;
 	        result.KeyPrefix = cfg.KeyPrefix;
 	        result.Password = cfg.Password;
+	        result.Ssl = cfg.Ssl;
 
 			List<Core.Configuration.RedisHost> hosts = new List<Core.Configuration.RedisHost>();
 


### PR DESCRIPTION
It retrieves the `ssl` config property but doesn't map it in the `GetConfig()` method.