### PR TITLE
Update references and target frameworks to use StackExchange.Redis 2.0

### DIFF
--- a/src/StackExchange.Redis.Extensions.Binary/StackExchange.Redis.Extensions.Binary.csproj
+++ b/src/StackExchange.Redis.Extensions.Binary/StackExchange.Redis.Extensions.Binary.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net45;net46</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net461;net472</TargetFrameworks>
 
 		<Title>StackExchange.Redis.Extensions is a library that extends StackExchange.Redis with different implementation, this is one of them.</Title>
 		<Summary>StackExchange.Redis.Extensions is a library that extends StackExchange.Redis with different implementation, this is one of them.</Summary>

--- a/src/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.csproj
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net45;net46</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net461;net472</TargetFrameworks>
 		
 		<Title>StackExchange.Redis.Extensions is a library that extends StackExchange.Redis</Title>
 		<Summary>StackExchange.Redis.Extensions is a library that extends StackExchange.Redis</Summary>
@@ -53,8 +53,7 @@ To store complex data It requires one of the following implementations:
 - Support for Keyspace isolation;</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 	</PropertyGroup>
-
 	<ItemGroup>
-		<PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" />
+	  <PackageReference Include="StackExchange.Redis" Version="2.0.513" />
 	</ItemGroup>
 </Project>

--- a/src/StackExchange.Redis.Extensions.Jil/StackExchange.Redis.Extensions.Jil.csproj
+++ b/src/StackExchange.Redis.Extensions.Jil/StackExchange.Redis.Extensions.Jil.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net45;net46</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net461;net472</TargetFrameworks>
 
 		<Title>StackExchange.Redis.Extensions is a library that extends StackExchange.Redis with different implementation, this is one of them.</Title>
 		<Summary>StackExchange.Redis.Extensions is a library that extends StackExchange.Redis with different implementation, this is one of them.</Summary>

--- a/src/StackExchange.Redis.Extensions.LegacyConfiguration/StackExchange.Redis.Extensions.LegacyConfiguration.csproj
+++ b/src/StackExchange.Redis.Extensions.LegacyConfiguration/StackExchange.Redis.Extensions.LegacyConfiguration.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>StackExchange.Redis.Extensions.LegacyConfiguration</RootNamespace>
     <AssemblyName>StackExchange.Redis.Extensions.LegacyConfiguration</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/StackExchange.Redis.Extensions.MsgPack/StackExchange.Redis.Extensions.MsgPack.csproj
+++ b/src/StackExchange.Redis.Extensions.MsgPack/StackExchange.Redis.Extensions.MsgPack.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	  <TargetFrameworks>netstandard2.0;net45;net46</TargetFrameworks>
+	  <TargetFrameworks>netstandard2.0;net461;net472</TargetFrameworks>
 
 		<Title>StackExchange.Redis.Extensions is a library that extends StackExchange.Redis with different implementation, this is one of them.</Title>
 		<Summary>StackExchange.Redis.Extensions is a library that extends StackExchange.Redis with different implementation, this is one of them.</Summary>

--- a/src/StackExchange.Redis.Extensions.Newtonsoft/StackExchange.Redis.Extensions.Newtonsoft.csproj
+++ b/src/StackExchange.Redis.Extensions.Newtonsoft/StackExchange.Redis.Extensions.Newtonsoft.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	  <TargetFrameworks>netstandard2.0;net45;net46</TargetFrameworks>
+	  <TargetFrameworks>netstandard2.0;net461;net472</TargetFrameworks>
 
 		<Title>StackExchange.Redis.Extensions is a library that extends StackExchange.Redis with different implementation, this is one of them.</Title>
 		<Summary>StackExchange.Redis.Extensions is a library that extends StackExchange.Redis with different implementation, this is one of them.</Summary>

--- a/src/StackExchange.Redis.Extensions.Protobuf/StackExchange.Redis.Extensions.Protobuf.csproj
+++ b/src/StackExchange.Redis.Extensions.Protobuf/StackExchange.Redis.Extensions.Protobuf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	  <TargetFrameworks>netstandard2.0;net45;net46</TargetFrameworks>
+	  <TargetFrameworks>netstandard2.0;net461;net472</TargetFrameworks>
 
 		<Title>StackExchange.Redis.Extensions is a library that extends StackExchange.Redis with different implementation, this is one of them.</Title>
 		<Summary>StackExchange.Redis.Extensions is a library that extends StackExchange.Redis with different implementation, this is one of them.</Summary>

--- a/src/StackExchange.Redis.Extensions.Utf8Json/StackExchange.Redis.Extensions.Utf8Json.csproj
+++ b/src/StackExchange.Redis.Extensions.Utf8Json/StackExchange.Redis.Extensions.Utf8Json.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	  <TargetFrameworks>netstandard2.0;net45;net46</TargetFrameworks>
+	  <TargetFrameworks>netstandard2.0;net461;net472</TargetFrameworks>
 
 		<Title>StackExchange.Redis.Extensions is a library that extends StackExchange.Redis with different implementation, this is one of them.</Title>
 		<Summary>StackExchange.Redis.Extensions is a library that extends StackExchange.Redis with different implementation, this is one of them.</Summary>

--- a/tests/StackExchange.Redis.Extensions.LegacyConfiguration.Tests/App.config
+++ b/tests/StackExchange.Redis.Extensions.LegacyConfiguration.Tests/App.config
@@ -7,7 +7,7 @@
 	<redisCacheClient allowAdmin="true" ssl="false" connectTimeout="3000" database="24">
 		<serverEnumerationStrategy mode="Single" targetRole="PreferSlave" unreachableServerAction="IgnoreIfOtherAvailable" /> 
 		<hosts>
-			<add host="192.168.56.1" cachePort="6379" />
+			<add host="127.0.0.1" cachePort="6379" />
 		</hosts>
 	</redisCacheClient>
 

--- a/tests/StackExchange.Redis.Extensions.LegacyConfiguration.Tests/App.config
+++ b/tests/StackExchange.Redis.Extensions.LegacyConfiguration.Tests/App.config
@@ -7,7 +7,7 @@
 	<redisCacheClient allowAdmin="true" ssl="false" connectTimeout="3000" database="24">
 		<serverEnumerationStrategy mode="Single" targetRole="PreferSlave" unreachableServerAction="IgnoreIfOtherAvailable" /> 
 		<hosts>
-			<add host="127.0.0.1" cachePort="6379" />
+			<add host="192.168.56.1" cachePort="6379" />
 		</hosts>
 	</redisCacheClient>
 

--- a/tests/StackExchange.Redis.Extensions.Tests/StackExchange.Redis.Extensions.Tests.csproj
+++ b/tests/StackExchange.Redis.Extensions.Tests/StackExchange.Redis.Extensions.Tests.csproj
@@ -6,6 +6,7 @@
   
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+		<PackageReference Include="StackExchange.Redis" Version="2.0.513" />
 		<PackageReference Include="xunit" Version="2.3.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
 		<PackageReference Include="Jil" Version="2.16.0" />
@@ -13,7 +14,6 @@
 		<PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
 		<PackageReference Include="protobuf-net" Version="2.3.13" />
 		<PackageReference Include="Utf8Json" Version="1.3.7" />
-		<PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" />
 		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
 	</ItemGroup>
 	


### PR DESCRIPTION
This pull request is meant to update references and target frameworks to use StackExchange.Redis 2.0.513.

I have found that there was an issue created asking regarding this - #148 and furthermore we are undergoing an update to Redis 2.0 on our project as well, therefore I wanted to contribute and update the Extensions project as well, because we are using it too.

I have ran all the tests with a local Redis instance and all of them appear to pass.

**References**
- Release notes and reasoning regarding .NET 4.7.2 - https://stackexchange.github.io/StackExchange.Redis/ReleaseNotes.html#20495
- Dependencies, reason for TargetFramework updates - https://www.nuget.org/packages/StackExchange.Redis/ - 

**To do**
- [ ] One of the things left to do is set a new version for the NuGet packages, considering this is a breaking change and will not work on earlier versions of StackExchange.Redis.