### PR TITLE
Added SyncTimeout in Redis configuration

### DIFF
--- a/samples/StackExchange.Redis.Extensions.AspNetCore.Sample/Configurations/redis.json
+++ b/samples/StackExchange.Redis.Extensions.AspNetCore.Sample/Configurations/redis.json
@@ -4,6 +4,7 @@
 		"allowAdmin": true,
 		"ssl": false,
 		"connectTimeout": 5000,
+		"syncTimeout": 2000,
 		"database": 0,
 		"hosts": [
 			{

--- a/src/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
@@ -38,6 +38,11 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
 		/// </summary>
 		public int ConnectTimeout { get; set; } = 5000;
 
+        /// <summary>
+        /// Time (ms) to allow for synchronous operations
+        /// </summary>
+        public int SyncTimeout { get; set; } = 1000;
+		
 		/// <summary>
 		/// If true, Connect will not create a connection while no servers are available
 		/// </summary>
@@ -83,6 +88,7 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
 						AllowAdmin = AllowAdmin,
 						Password = Password,
 						ConnectTimeout = ConnectTimeout,
+						SyncTimeout = SyncTimeout,
 						AbortOnConnectFail = AbortOnConnectFail
 					};
 

--- a/src/StackExchange.Redis.Extensions.LegacyConfiguration/Configuration/IRedisCachingConfiguration.cs
+++ b/src/StackExchange.Redis.Extensions.LegacyConfiguration/Configuration/IRedisCachingConfiguration.cs
@@ -40,6 +40,11 @@
 		int ConnectTimeout { get; }
 
 		/// <summary>
+		/// Time (ms) to allow for synchronous operations
+		/// </summary>
+		int SyncTimeout { get; }
+
+		/// <summary>
 		/// If true, Connect will not create a connection while no servers are available
 		/// </summary>
 		bool AbortOnConnectFail { get; }

--- a/src/StackExchange.Redis.Extensions.LegacyConfiguration/RedisCachingSectionHandler.cs
+++ b/src/StackExchange.Redis.Extensions.LegacyConfiguration/RedisCachingSectionHandler.cs
@@ -82,6 +82,21 @@ namespace StackExchange.Redis.Extensions.LegacyConfiguration
 		}
 
 		/// <summary>
+		/// Time (ms) to allow for synchronous operations
+		/// </summary>
+		[ConfigurationProperty("syncTimeout")]
+		public int SyncTimeout
+		{
+			get
+			{
+			    var value = this["syncTimeout"]?.ToString();
+
+				int result;
+			    return !string.IsNullOrWhiteSpace(value) && int.TryParse(value, out result) ? result : 1000;
+			}
+		}
+
+		/// <summary>
 		/// If true, Connect will not create a connection while no servers are available
 		/// </summary>
 		[ConfigurationProperty("abortOnConnectFail")]
@@ -143,6 +158,7 @@ namespace StackExchange.Redis.Extensions.LegacyConfiguration
 	        result.AbortOnConnectFail = cfg.AbortOnConnectFail;
 	        result.AllowAdmin = cfg.AllowAdmin;
 	        result.ConnectTimeout = cfg.ConnectTimeout;
+	        result.SyncTimeout = cfg.SyncTimeout;
 	        result.Database = cfg.Database;
 	        result.KeyPrefix = cfg.KeyPrefix;
 	        result.Password = cfg.Password;


### PR DESCRIPTION
Added SyncTimeout in Redis configuration
Fixes problems for Azure multi region:
https://azure.microsoft.com/en-us/blog/investigating-timeout-exceptions-in-stackexchange-redis-for-azure-redis-cache/

Followed docs:
https://stackexchange.github.io/StackExchange.Redis/Configuration.html

Note: I had problems with the indenting.