### PR TITLE
Fix static problem for multiple RedisConfiguration

### DIFF
--- a/src/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
@@ -4,8 +4,8 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
 {
 	public class RedisConfiguration
 	{
-		private static ConnectionMultiplexer connection;
-		private static ConfigurationOptions options;
+		private ConnectionMultiplexer connection;
+		private ConfigurationOptions options;
 
 		/// <summary>
 		/// The key separation prefix used for all cache entries


### PR DESCRIPTION
If static RedisConfiguration ConfigurationOptions, then if you use multiple RedisConfiguration it will be singleton and will always use the first option set resulting in bad configs.