### PR TITLE
Fixed SearchKeys method returning keys with KeyPrefix included

### DIFF
--- a/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
+++ b/src/StackExchange.Redis.Extensions.Core/StackExchangeRedisCacheClient.cs
@@ -1087,7 +1087,7 @@ namespace StackExchange.Redis.Extensions.Core
 				while (nextCursor != 0);
 			}
 
-			return keys;
+			return !string.IsNullOrEmpty(keyprefix) ? keys.Select(k => k.Substring(keyprefix.Length)) : keys;
 		}
 
 		/// <summary>

--- a/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
+++ b/tests/StackExchange.Redis.Extensions.Tests/CacheClientTestBase.cs
@@ -183,7 +183,28 @@ namespace StackExchange.Redis.Extensions.Tests
 			Assert.True(keys.Count() == 2);
 		}
 
-		[Fact]
+	    [Fact]
+	    public void SearchKeys_With_Key_Prefix_Should_Return_Keys_Without_Prefix()
+	    {
+	        var client = new StackExchangeRedisCacheClient(Serializer, "localhost", "MyPrefix__");
+
+	        var values = Range(0, 10)
+	            .Select(i => new TestClass<string>($"mykey{i}", Guid.NewGuid().ToString()))
+	            .ToArray();
+
+            values.ForEach(x => client.Add(x.Key, x.Value));
+
+            var result = client.SearchKeys("*mykey*").OrderBy(k => k).ToList();
+
+	        Assert.True(result.Count == 10);
+
+            for (int i = 0; i < result.Count; i++)
+	        {
+	            Assert.Equal(result[i], values[i].Key);
+            }
+	    }
+
+        [Fact]
 		public void Exist_With_Valid_Object_Should_Return_The_Correct_Instance()
 		{
 			var values = Range(0, 2)


### PR DESCRIPTION
I ran some tests to make sure the string manipulation on the keys list won't add too much overhead to the method.

Here are the results:

100K records:
with prefix 326ms
without prefix 305ms

500K records:
with prefix 1620ms
without prefix 1589ms

1M records:
with prefix 3176ms
without prefix 3139ms