### PR TITLE
Added configuration option to exclude commands

### DIFF
--- a/src/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Security;
+﻿using System.Collections.Generic;
+using System.Net.Security;
 
 namespace StackExchange.Redis.Extensions.Core.Configuration
 {
@@ -17,6 +18,7 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
         private RedisHost[] hosts;
         private ServerEnumerationStrategy serverEnumerationStrategy;
         private int poolSize = 10;
+	private string[] excludeCommands;
 
         /// <summary>
         /// The key separation prefix used for all cache entries
@@ -172,6 +174,19 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
                 ResetConfigurationOptions();
             }
         }
+		
+        /// <summary>
+        /// Exclude commands
+        /// </summary>
+        public string[] ExcludeCommands
+        {
+            get => excludeCommands;
+            set
+            {
+                excludeCommands = value;
+                ResetConfigurationOptions();
+            }
+        }
 
         /// <summary>
         /// A RemoteCertificateValidationCallback delegate responsible for validating the certificate supplied by the remote party; note
@@ -194,6 +209,15 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
 						SyncTimeout = SyncTimeout,
 						AbortOnConnectFail = AbortOnConnectFail,
 					};
+					
+					// EXCLUDE commands if any requested
+					if (ExcludeCommands != null)
+					{
+						options.CommandMap = CommandMap.Create(
+							new HashSet<string>(ExcludeCommands),
+							available: false
+						);
+					}
 
 					foreach (var redisHost in Hosts)
 						options.EndPoints.Add(redisHost.Host, redisHost.Port);


### PR DESCRIPTION
`StackExchange.Redis` allows to exclude certain commands which was missing when working with `StackExchange.Redis.Extensions.Core.Configuration`, in my case I'm working with a Redis like implementation that doesn't support certain commands which I needed to exclude.

To add the feature I updated `src/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs` and added a property that accepts a string array of commands to exclude.  If it exists then I pass that on to `StackExchange.Redis` `ConfigurationOptions`.

I used the sample code from the following `StackExchange.Redis` doc:

https://github.com/StackExchange/StackExchange.Redis/blob/e6be14746fcc30412d00c2ba2463fc8e43eb6f89/docs/Configuration.md#automatic-and-manual-configuration