### PR TITLE
Added support for ConnectionMultiplexer.RegisterProfiler

### DIFF
--- a/src/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net.Security;
+using StackExchange.Redis.Profiling;
 
 namespace StackExchange.Redis.Extensions.Core.Configuration
 {
@@ -20,6 +22,7 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
         private int poolSize = 5;
 	    private string[] excludeCommands;
         private string configurationChannel = null;
+        private Func<ProfilingSession> profilingSessionProvider;
 
         /// <summary>
         /// The key separation prefix used for all cache entries
@@ -198,6 +201,19 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
             set
             {
                 excludeCommands = value;
+                ResetConfigurationOptions();
+            }
+        }
+
+        /// <summary>
+        /// Redis Profiler to attach to ConnectionMultiplexer
+        /// </summary>
+        public Func<ProfilingSession> ProfilingSessionProvider
+        {
+            get => profilingSessionProvider;
+            set
+            {
+                profilingSessionProvider = value;
                 ResetConfigurationOptions();
             }
         }

--- a/src/StackExchange.Redis.Extensions.Core/Implementations/RedisCacheConnectionPoolManager.cs
+++ b/src/StackExchange.Redis.Extensions.Core/Implementations/RedisCacheConnectionPoolManager.cs
@@ -50,7 +50,15 @@ namespace StackExchange.Redis.Extensions.Core.Implementations
 
 			for (int i = 0; i < redisConfiguration.PoolSize; i++)
 			{
-				connections.Add(new Lazy<ConnectionMultiplexer>(() => ConnectionMultiplexer.Connect(redisConfiguration.ConfigurationOptions)));
+				connections.Add(new Lazy<ConnectionMultiplexer>(() =>
+                {
+                    var multiplexer = ConnectionMultiplexer.Connect(redisConfiguration.ConfigurationOptions);
+                    if (redisConfiguration.ProfilingSessionProvider != null)
+                    {
+                        multiplexer.RegisterProfiler(redisConfiguration.ProfilingSessionProvider);
+                    }
+                    return multiplexer;
+                }));
 			}
 		}
 	}


### PR DESCRIPTION
Added ProfilingSessionProvider to RedisConfiguration. RedisCacheConnectionPoolManager calls RegisterProfiler() on all new multiplexers instantiated if this is set.