### PR TITLE
not cached connection errors

### DIFF
--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisCacheConnectionPoolManager.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisCacheConnectionPoolManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Threading;
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -101,7 +102,8 @@ namespace StackExchange.Redis.Extensions.Core.Implementations
 
         private void EmitConnection()
         {
-            this.connections.Add(new Lazy<StateAwareConnection>(() =>
+            this.connections.Add(new Lazy<StateAwareConnection>(
+            () =>
             {
                 this.logger.LogDebug("Creating new Redis connection.");
 
@@ -114,7 +116,8 @@ namespace StackExchange.Redis.Extensions.Core.Implementations
                     multiplexer = multiplexer.GetSentinelMasterConnection(redisConfiguration.ConfigurationOptions);
 
                 return new StateAwareConnection(multiplexer, this.EmitConnection, logger);
-            }));
+            },
+            LazyThreadSafetyMode.PublicationOnly));
         }
 
         private void EmitConnections()


### PR DESCRIPTION
Hey guys.

recently we faced with reconnection issue and the problem was in the lazy connection initialization. 
root cause of the problem is [Exception in Lazy initialization](https://docs.microsoft.com/en-us/dotnet/framework/performance/lazy-initialization#exceptions-in-lazy-objects).

how to reproduce:
- perform connection (success)
- turn off redis
- try to connect (expected error)
- turn on redis
- try to connect (unexpected error)

fix:

set LazyThreadSafetyMode to PublicationOnly