### PR TITLE
ISerializer,IRedisDatabase Non-generic Enhance

### DIFF
--- a/src/core/StackExchange.Redis.Extensions.Core/Abstractions/IRedisDatabase.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Abstractions/IRedisDatabase.cs
@@ -75,6 +75,15 @@ namespace StackExchange.Redis.Extensions.Core.Abstractions
         Task<T> GetAsync<T>(string key, TimeSpan expiresIn, CommandFlags flag = CommandFlags.None);
 
         /// <summary>
+        ///     Get the object with the specified key from Redis database
+        /// </summary>
+        /// <param name="key">The cache key.</param>
+        /// <param name="returnType">The type of the object to convert to and return.</param>
+        /// <param name="flag">Behaviour markers associated with a given command</param>
+        /// <returns>Null if not present, otherwise the instance of T.</returns>
+        Task<object> GetAsync(string key, Type returnType, CommandFlags flag = CommandFlags.None);
+
+        /// <summary>
         ///     Adds the specified instance to the Redis database.
         /// </summary>
         /// <typeparam name="T">The type of the class to add to Redis</typeparam>

--- a/src/core/StackExchange.Redis.Extensions.Core/ISerializer.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/ISerializer.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+﻿using System;
 
 namespace StackExchange.Redis.Extensions.Core
 {
@@ -23,5 +23,15 @@ namespace StackExchange.Redis.Extensions.Core
         /// The instance of the specified Item
         /// </returns>
         T Deserialize<T>(byte[] serializedObject);
+
+        /// <summary>
+        /// Deserializes the specified bytes.
+        /// </summary>
+        /// <param name="serializedObject">The serialized object.</param>
+        /// <param name="returnType">The type of the object to convert to and return.</param>
+        /// <returns>
+        /// The instance of the specified Item
+        /// </returns>
+        object Deserialize(byte[] serializedObject, Type returnType);
     }
 }

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
@@ -117,6 +117,17 @@ namespace StackExchange.Redis.Extensions.Core.Implementations
         }
 
         /// <inheritdoc/>
+        public async Task<object> GetAsync(string key, Type returnType, CommandFlags flag = CommandFlags.None)
+        {
+            var valueBytes = await Database.StringGetAsync(key, flag).ConfigureAwait(false);
+
+            if (!valueBytes.HasValue)
+                return default;
+
+            return Serializer.Deserialize(valueBytes, returnType);
+        }
+
+        /// <inheritdoc/>
         public Task<bool> AddAsync<T>(string key, T value, When when = When.Always, CommandFlags flag = CommandFlags.None)
         {
             var entryBytes = value.OfValueSize(Serializer, maxValueLength, key);

--- a/src/serializers/StackExchange.Redis.Extensions.Binary/BinarySerializer.cs
+++ b/src/serializers/StackExchange.Redis.Extensions.Binary/BinarySerializer.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
 using StackExchange.Redis.Extensions.Core;
@@ -18,6 +19,14 @@ namespace StackExchange.Redis.Extensions.Binary
             using var ms = new MemoryStream(serializedObject);
 
             return (T)binaryFormatter.Deserialize(ms);
+        }
+
+        /// <inheritdoc/>
+        public object Deserialize(byte[] serializedObject, Type returnType)
+        {
+            using var ms = new MemoryStream(serializedObject);
+
+            return binaryFormatter.Deserialize(ms);
         }
 
         /// <inheritdoc/>

--- a/src/serializers/StackExchange.Redis.Extensions.Jil/JilSerializer.cs
+++ b/src/serializers/StackExchange.Redis.Extensions.Jil/JilSerializer.cs
@@ -53,5 +53,12 @@ namespace StackExchange.Redis.Extensions.Jil
             var jsonString = encoding.GetString(serializedObject);
             return JSON.Deserialize<T>(jsonString);
         }
+
+        /// <inheritdoc/>
+        public object Deserialize(byte[] serializedObject, Type returnType)
+        {
+            var jsonString = encoding.GetString(serializedObject);
+            return JSON.Deserialize(jsonString, returnType);
+        }
     }
 }

--- a/src/serializers/StackExchange.Redis.Extensions.MsgPack/MsgPackObjectSerializer.cs
+++ b/src/serializers/StackExchange.Redis.Extensions.MsgPack/MsgPackObjectSerializer.cs
@@ -47,6 +47,21 @@ namespace StackExchange.Redis.Extensions.MsgPack
         }
 
         /// <inheritdoc/>
+        public object Deserialize(byte[] serializedObject, Type returnType)
+        {
+            if (returnType == typeof(string))
+            {
+                return Convert.ChangeType(encoding.GetString(serializedObject), returnType);
+            }
+
+            var serializer = MessagePackSerializer.Get(returnType);
+
+            using var byteStream = new MemoryStream(serializedObject);
+
+            return serializer.Unpack(byteStream);
+        }
+
+        /// <inheritdoc/>
         public byte[] Serialize(object item)
         {
             if (item is string)

--- a/src/serializers/StackExchange.Redis.Extensions.Newtonsoft/NewtonsoftSerializer.cs
+++ b/src/serializers/StackExchange.Redis.Extensions.Newtonsoft/NewtonsoftSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 
 using Newtonsoft.Json;
 
@@ -52,6 +53,13 @@ namespace StackExchange.Redis.Extensions.Newtonsoft
         {
             var jsonString = encoding.GetString(serializedObject);
             return JsonConvert.DeserializeObject<T>(jsonString, settings);
+        }
+
+        /// <inheritdoc/>
+        public object Deserialize(byte[] serializedObject, Type returnType)
+        {
+            var jsonString = encoding.GetString(serializedObject);
+            return JsonConvert.DeserializeObject(jsonString, returnType, settings);
         }
     }
 }

--- a/src/serializers/StackExchange.Redis.Extensions.Protobuf/ProtobufSerializer.cs
+++ b/src/serializers/StackExchange.Redis.Extensions.Protobuf/ProtobufSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 using ProtoBuf;
 
@@ -27,6 +28,14 @@ namespace StackExchange.Redis.Extensions.Protobuf
             using var ms = new MemoryStream(serializedObject);
 
             return Serializer.Deserialize<T>(ms);
+        }
+
+        /// <inheritdoc/>
+        public object Deserialize(byte[] serializedObject, Type returnType)
+        {
+            using var ms = new MemoryStream(serializedObject);
+
+            return Serializer.Deserialize(returnType, ms);
         }
     }
 }

--- a/src/serializers/StackExchange.Redis.Extensions.System.Text.Json/SystemTextJsonSerializer.cs
+++ b/src/serializers/StackExchange.Redis.Extensions.System.Text.Json/SystemTextJsonSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System;
+using System.Text.Json;
 
 using StackExchange.Redis.Extensions.Core;
 
@@ -19,6 +20,12 @@ namespace StackExchange.Redis.Extensions.System.Text.Json
         public byte[] Serialize(object item)
         {
             return JsonSerializer.SerializeToUtf8Bytes(item, SerializationOptions.Flexible);
+        }
+
+        /// <inheritdoc/>
+        public object Deserialize(byte[] serializedObject, Type returnType)
+        {
+            return JsonSerializer.Deserialize(serializedObject, returnType, SerializationOptions.Flexible);
         }
     }
 }

--- a/src/serializers/StackExchange.Redis.Extensions.Utf8Json/Utf8JsonSerializer.cs
+++ b/src/serializers/StackExchange.Redis.Extensions.Utf8Json/Utf8JsonSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using System.Threading.Tasks;
 
 using StackExchange.Redis.Extensions.Core;
@@ -27,6 +28,12 @@ namespace StackExchange.Redis.Extensions.Utf8Json
         public T Deserialize<T>(byte[] serializedObject)
         {
             return global::Utf8Json.JsonSerializer.Deserialize<T>(serializedObject);
+        }
+
+        /// <inheritdoc/>
+        public object Deserialize(byte[] serializedObject, Type returnType)
+        {
+            return global::Utf8Json.JsonSerializer.NonGeneric.Deserialize(returnType, serializedObject);
         }
     }
 }

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/CacheClientTestBase.cs
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/CacheClientTestBase.cs
@@ -8,9 +8,11 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
+using StackExchange.Redis.Extensions.Binary;
 using StackExchange.Redis.Extensions.Core.Abstractions;
 using StackExchange.Redis.Extensions.Core.Configuration;
 using StackExchange.Redis.Extensions.Core.Implementations;
+using StackExchange.Redis.Extensions.Protobuf;
 using StackExchange.Redis.Extensions.Tests.Extensions;
 using StackExchange.Redis.Extensions.Tests.Helpers;
 
@@ -534,6 +536,53 @@ namespace StackExchange.Redis.Extensions.Core.Tests
             Assert.True(added);
             Assert.True(db.KeyExists("my Key"));
             Assert.Equal(dbValue, d);
+        }
+
+        [Fact]
+        public async Task Adding_Value_Type_Should_Return_Non_Generic_Correct_Value()
+        {
+            var d = new TestClass<string> { Key = $"key21", Value = "value21" };
+            var added = await Sut.GetDbFromConfiguration().AddAsync("my Key", d);
+
+            // TODO: Assuming that only the type of TestClass<string> can be obtained here.
+            var returnType = typeof(TestClass<string>);
+
+            // TODO: Use non-generic methods to get results.
+            var dbValue = await Sut.GetDbFromConfiguration().GetAsync("my Key", returnType);
+            Assert.True(added);
+            Assert.True(db.KeyExists("my Key"));
+
+            // TODO: dbValue equal.
+            Assert.Equal(dbValue, d);
+        }
+
+        [Fact]
+        public async Task Adding_Value_Type_Validate_Generic_Return_Object()
+        {
+            var d = new TestClass<string> { Key = $"key21", Value = "value21" };
+            var added = await Sut.GetDbFromConfiguration().AddAsync("my Key", d);
+            Assert.True(added);
+            Assert.True(db.KeyExists("my Key"));
+            if (Sut.GetDbFromConfiguration().Serializer is ProtobufSerializer)
+            {
+                // TODO: ProtobufSerializer generic get object throws an ArgumentNullException.
+                await Assert.ThrowsAsync<ArgumentNullException>(() => Sut.GetDbFromConfiguration().GetAsync<object>("my Key"));
+            }
+            else
+            {
+                // TODO: Use generic methods to get results.
+                var dbValue = await Sut.GetDbFromConfiguration().GetAsync<object>("my Key");
+                if (Sut.GetDbFromConfiguration().Serializer is BinarySerializer)
+                {
+                    // TODO: BinarySerializer dbValue equal.
+                    Assert.Equal(dbValue, d);
+                }
+                else
+                {
+                    // TODO: dbValue not equal.
+                    Assert.NotEqual(dbValue, d);
+                }
+            }
         }
 
         [Fact]


### PR DESCRIPTION
 Hi@imperugo 
Let me describe the usage scenario.

GetAsync <object> (cachekey) The return type is JObject, JDocment..., I need to specify the value return type.

Use GetAsync(cachekey, typeof(MyClass)) to return the type I want,.


```
//Now I have to do this to get the specified type.

var redisVlue = await _redisCacheClient.Db0.Database.StringGetAsync(cacheKey);
cacheValue = redisVlue.HasValue ? JsonSerializer.Deserialize(redisVlue, returnType) : cacheValue;
```

[The test code is used to illustrate the usage scenarios for enhancing this function.](https://github.com/oTcom/StackExchange.Redis.Extensions/blob/88bc96e4e53e9271bdd0971a9e31d283fb10e730/tests/StackExchange.Redis.Extensions.Core.Tests/CacheClientTestBase.cs#L541-L586)