### PR TITLE
Make ConfigurationOptions initialization thread-safe

### DIFF
--- a/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
@@ -287,13 +287,15 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
             {
                 if (options == null)
                 {
+                    ConfigurationOptions newOptions;
+
                     if (!string.IsNullOrEmpty(ConnectionString))
                     {
-                        options = ConfigurationOptions.Parse(ConnectionString);
+                        newOptions = ConfigurationOptions.Parse(ConnectionString);
                     }
                     else
                     {
-                        options = new ConfigurationOptions
+                        newOptions = new ConfigurationOptions
                         {
                             Ssl = Ssl,
                             AllowAdmin = AllowAdmin,
@@ -308,22 +310,24 @@ namespace StackExchange.Redis.Extensions.Core.Configuration
 
                         if (IsSentinelCluster)
                         {
-                            options.ServiceName = ServiceName;
-                            options.CommandMap = CommandMap.Sentinel;
+                            newOptions.ServiceName = ServiceName;
+                            newOptions.CommandMap = CommandMap.Sentinel;
                         }
 
                         foreach (var redisHost in Hosts)
-                            options.EndPoints.Add(redisHost.Host, redisHost.Port);
+                            newOptions.EndPoints.Add(redisHost.Host, redisHost.Port);
                     }
 
                     if (ExcludeCommands != null)
                     {
-                        options.CommandMap = CommandMap.Create(
+                        newOptions.CommandMap = CommandMap.Create(
                             new HashSet<string>(ExcludeCommands),
                             available: false);
                     }
 
-                    options.CertificateValidation += CertificateValidation;
+                    newOptions.CertificateValidation += CertificateValidation;
+
+                    options = newOptions;
                 }
 
                 return options;


### PR DESCRIPTION
One of our customers ran into the following error:

```
   at StackExchange.Redis.EndPointCollection.InsertItem(Int32 index, EndPoint item) in \/_\/src\/StackExchange.Redis\/EndPointCollection.cs:line 91
   at System.Collections.ObjectModel.Collection`1.Add(T item)
   at StackExchange.Redis.EndPointCollection.Add(String host, Int32 port) in \/_\/src\/StackExchange.Redis\/EndPointCollection.cs:line 53
   at StackExchange.Redis.Extensions.Core.Configuration.RedisConfiguration.get_ConfigurationOptions()
   at StackExchange.Redis.Extensions.Core.Implementations.RedisCacheConnectionPoolManager.<EmitConnection>b__7_0()
   at System.Lazy`1.PublicationOnlyViaFactory(LazyHelper initializer)
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.get_Value()
   at StackExchange.Redis.Extensions.Core.Implementations.RedisCacheConnectionPoolManager.GetConnection()
   at StackExchange.Redis.Extensions.Core.Implementations.RedisDatabase.get_Database()
   at StackExchange.Redis.Extensions.Core.Implementations.RedisDatabase.GetAsync[T](String key, CommandFlags flag)
```

After investigation, it seems it can happen when multiple threads are accessing the `ConfigurationOptions` property of the `RedisConfiguration` object (in this case, in the initializer of the `Lazy<T>` instance created in `RedisCacheConnectionPoolManager.EmitConnection`).

The issue is caused by the lazy initialization of `ConfigurationOptions` not being thread-safe. Multiple threads can get past the `if (options == null)` check, then simultaneously try to add the same endpoints to the same instance of options: `options.EndPoints.Add(redisHost.Host, redisHost.Port);`

The fix makes sure that the `ConfigurationOptions` instance is fully initialized before being assigned to the `options` field.


Repro:

```csharp
    class Program
    {
        static void Main(string[] args)
        {
            const int NumberOfThreads = 8;

            for (int i = 0; i < 1000; i++)
            {
                if (TryReadingConfiguration(NumberOfThreads, i))
                {
                    break;
                }
            }

            Console.WriteLine("Done");
            Console.ReadLine();
        }

        private static bool TryReadingConfiguration(int numberOfThreads, int iteration)
        {
            using var barrier = new Barrier(numberOfThreads);

            var configuration = CreateConfiguration();

            var tasks = new Task[numberOfThreads];

            for (int i = 0; i < numberOfThreads; i++)
            {
                tasks[i] = Task.Factory.StartNew(() =>
                {
                    barrier.SignalAndWait();

                    _ = configuration.ConfigurationOptions;

                }, TaskCreationOptions.LongRunning);
            }

            try
            {
                Task.WaitAll(tasks);
            }
            catch (Exception ex)
            {
                Console.WriteLine($"Error on iteration {iteration}: {ex}");
                return true;
            }

            return false;
        }

        private static RedisConfiguration CreateConfiguration()
        {
            var redisConfiguration = new RedisConfiguration()
            {
                AbortOnConnectFail = true,
                KeyPrefix = "Test",
                Hosts = new RedisHost[]
                {
                    new RedisHost
                    {
                        Host = "cache",
                        Port = int.Parse("6379")
                    },
                },
                AllowAdmin = true,
                Database = 0,
                ServerEnumerationStrategy = new ServerEnumerationStrategy()
                {
                    Mode = ServerEnumerationStrategy.ModeOptions.All,
                    TargetRole = ServerEnumerationStrategy.TargetRoleOptions.Any,
                    UnreachableServerAction = ServerEnumerationStrategy.UnreachableServerActionOptions.Throw
                },
                PoolSize = 5
            };

            return redisConfiguration;
        }
    }
```


