### PR TITLE
Fix/prevent pool size exceeds configuration under high concurrency

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   <!-- General information -->
   <PropertyGroup>
     <Authors>Ugo Lattanzi</Authors>
-    <VersionPrefix>6.3.6</VersionPrefix>
+    <VersionPrefix>6.3.7</VersionPrefix>
     <VersionSuffix>pre</VersionSuffix>
     
     <!-- <TargetFrameworks>netstandard2.0;net461;net472;netcoreapp3.0;netcoreapp3.1</TargetFrameworks> -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,10 +4,9 @@
   <!-- General information -->
   <PropertyGroup>
     <Authors>Ugo Lattanzi</Authors>
-    <VersionPrefix>6.3.5</VersionPrefix>
-    <!--
+    <VersionPrefix>6.3.6</VersionPrefix>
     <VersionSuffix>pre</VersionSuffix>
-    -->
+    
     <!-- <TargetFrameworks>netstandard2.0;net461;net472;netcoreapp3.0;netcoreapp3.1</TargetFrameworks> -->
     <TargetFrameworks>netstandard2.0;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <IncludeSource>True</IncludeSource>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,9 +4,10 @@
   <!-- General information -->
   <PropertyGroup>
     <Authors>Ugo Lattanzi</Authors>
-    <VersionPrefix>6.3.7</VersionPrefix>
+    <VersionPrefix>6.3.5</VersionPrefix>
+    <!--
     <VersionSuffix>pre</VersionSuffix>
-    
+    -->
     <!-- <TargetFrameworks>netstandard2.0;net461;net472;netcoreapp3.0;netcoreapp3.1</TargetFrameworks> -->
     <TargetFrameworks>netstandard2.0;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <IncludeSource>True</IncludeSource>

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisCacheConnectionPoolManager.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisCacheConnectionPoolManager.cs
@@ -26,9 +26,9 @@ namespace StackExchange.Redis.Extensions.Core.Implementations
         public RedisCacheConnectionPoolManager(RedisConfiguration redisConfiguration, ILogger<RedisCacheConnectionPoolManager> logger = null)
         {
             this.redisConfiguration = redisConfiguration ?? throw new ArgumentNullException(nameof(redisConfiguration));
-
             this.connections = new ConcurrentBag<Lazy<IStateAwareConnection>>();
             this.logger = logger ?? NullLogger<RedisCacheConnectionPoolManager>.Instance;
+            this.EmitConnections();
         }
 
         /// <inheritdoc/>
@@ -46,8 +46,6 @@ namespace StackExchange.Redis.Extensions.Core.Implementations
         /// <inheritdoc/>
         public IConnectionMultiplexer GetConnection()
         {
-            this.EmitConnections();
-
             var loadedLazies = this.connections.Where(lazy => lazy.IsValueCreated);
 
             if (loadedLazies.Count() == this.connections.Count)


### PR DESCRIPTION
I am experiencing a bug(#260) under high traffics, typically when k8s deployment started.

`EmitConnections` is reinitilizing the whole connection pool many times under high concurrency(there are no redis connection available when container started), causing total connections count are much higher than it should be. 

And sync mathod (`Connect`) is making things worse because it blocks thread then causing threadpool starvation.

I modified the code to fix this issue(tested on prod and works fine), however it breaks some old behavior(like lazy and connection info middleware). 

I am looking for a review and then get a proper fix 😀.