### PR TITLE
Include logging for additional Connection events

### DIFF
--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisCacheConnectionPoolManager.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisCacheConnectionPoolManager.cs
@@ -136,6 +136,8 @@ namespace StackExchange.Redis.Extensions.Core.Implementations
                 this.Connection = multiplexer ?? throw new ArgumentNullException(nameof(multiplexer));
                 this.Connection.ConnectionFailed += this.ConnectionFailed;
                 this.Connection.ConnectionRestored += this.ConnectionRestored;
+                this.Connection.InternalError += this.InternalError;   
+                this.Connection.ErrorMessage += this.ErrorMessage;                
 
                 this.logger = logger;
             }
@@ -150,6 +152,8 @@ namespace StackExchange.Redis.Extensions.Core.Implementations
             {
                 this.Connection.ConnectionFailed -= ConnectionFailed;
                 this.Connection.ConnectionRestored -= ConnectionRestored;
+                this.Connection.InternalError -= this.InternalError;   
+                this.Connection.ErrorMessage -= this.ErrorMessage;                   
 
                 Connection.Dispose();
             }
@@ -163,6 +167,16 @@ namespace StackExchange.Redis.Extensions.Core.Implementations
             {
                 logger.LogError("Redis connection error restored.");
             }
+            
+            private void InternalError(object sender, InternalErrorEventArgs e)
+            {
+                logger.LogError(e.Exception, "Redis internal error {0}.", e.Origin);
+            }               
+            
+            private void ErrorMessage(object sender, RedisErrorEventArgs e)
+            {
+                logger.LogError("Redis error: " + e.Message);
+            }                           
         }
     }
 }


### PR DESCRIPTION
Adding missing public events InternalError and ErrorMessage from IConnectionMultiplexer, so that they are getting into logs, too.