### PR TITLE
Add Bebop Support

### DIFF
--- a/StackExchange.Redis.Extensions.sln
+++ b/StackExchange.Redis.Extensions.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StackExchange.Redis.Extensi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StackExchange.Redis.Extensions.Protobuf", "src\serializers\StackExchange.Redis.Extensions.Protobuf\StackExchange.Redis.Extensions.Protobuf.csproj", "{11FC924C-275C-453F-8923-8AEF7EC90B82}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StackExchange.Redis.Extensions.Bebop", "src\serializers\StackExchange.Redis.Extensions.Bebop\StackExchange.Redis.Extensions.Bebop.csproj", "{5CCD8D5D-EBCA-4C6E-A345-F81666A53A6D}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StackExchange.Redis.Extensions.System.Text.Json", "src\serializers\StackExchange.Redis.Extensions.System.Text.Json\StackExchange.Redis.Extensions.System.Text.Json.csproj", "{C83F298E-4FE1-4128-89C1-EECB676FA913}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StackExchange.Redis.Extensions.Utf8Json", "src\serializers\StackExchange.Redis.Extensions.Utf8Json\StackExchange.Redis.Extensions.Utf8Json.csproj", "{3AB92D8A-14CB-4551-8C37-569067B9D6A5}"

--- a/src/serializers/StackExchange.Redis.Extensions.Bebop/BebopSerializer.cs
+++ b/src/serializers/StackExchange.Redis.Extensions.Bebop/BebopSerializer.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Bebop.Runtime;
+
+using StackExchange.Redis.Extensions.Core;
+
+namespace StackExchange.Redis.Extensions.Bebop
+{
+    /// <summary>
+    /// Bebop implementation of <see cref="ISerializer"/>
+    /// </summary>
+    public class BebopSerializer : ISerializer
+    {
+        /// <inheritdoc/>
+        public byte[] Serialize(object item)
+        {
+            var record = BebopMirror.FindRecordFromType(item.GetType());
+            return record.Encode(item);
+        }
+
+        /// <inheritdoc/>
+        public T Deserialize<T>(byte[] serializedObject)
+        {
+            var record = BebopMirror.FindRecordFromType(typeof(T));
+            if (record.Decode(serializedObject) is T value)
+                return value;
+
+            throw new InvalidOperationException($"Unable to cast {typeof(T)} to {record.Type}");
+        }
+    }
+}

--- a/src/serializers/StackExchange.Redis.Extensions.Bebop/StackExchange.Redis.Extensions.Bebop.csproj
+++ b/src/serializers/StackExchange.Redis.Extensions.Bebop/StackExchange.Redis.Extensions.Bebop.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Title>Use Bebop serialization with StackExchange.Redis.</Title>
+    <Summary>Use Bebop serialization with StackExchange.Redis.</Summary>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="bebop" Version="2.2.6" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\core\StackExchange.Redis.Extensions.Core\StackExchange.Redis.Extensions.Core.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR adds support for the schema based serialization format, [Bebop](https://github.com/RainwayApp/bebop). Unlike other serializers this library supports, Bebop has a strongly typed runtime and does not use reflection, nor can it serialize arbitrary POCO and system types. For that reason I did not add any test because it would require a larger refactor of the test suite.

`BebopMirror` handles resolving all the relevant types.