### PR TITLE
pass through build args

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,4 +1,4 @@
 FOR /F "tokens=*" %%G IN ('DIR /B /AD /S bin') DO RMDIR /S /Q "%%G"
 FOR /F "tokens=*" %%G IN ('DIR /B /AD /S obj') DO RMDIR /S /Q "%%G"
 
-dotnet run --project targets --no-launch-profile
+dotnet run --project targets --no-launch-profile -- %*

--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 
 find . -iname "bin" -o -iname "obj" | xargs rm -rf
 
-dotnet run --project targets --no-launch-profile
+dotnet run --project targets --no-launch-profile -- "$@"


### PR DESCRIPTION
otherwise, you can't do:

```bash
./build.sh -?
./build.sh build
```

etc.