### PR TITLE
fix documentation mistakes

### DIFF
--- a/doc/dependency-injection.md
+++ b/doc/dependency-injection.md
@@ -33,5 +33,5 @@ public static IServiceCollection AddStackExchangeRedisExtensions<T>(this IServic
 
 There are two important things to know in this code block:
 
-* Ho to retrieve an instance of the redis configuration ([here](configuration/) the solution);
-* Choise the right serializer ([here](serializers/) few options)
+* How to retrieve an instance of the redis configuration ([here](configuration/) the solution);
+* Choose the right serializer ([here](serializers/) few options)

--- a/doc/setup-1.md
+++ b/doc/setup-1.md
@@ -3,11 +3,11 @@
 In order to use StackExchange.Redis.Extensions you need to use two packages:
 
 * The `core` package;
-* The `serialier` package;
+* The `serializer` package;
 
 ### The Core Package
 
-The core package is the library includes all the method you need into your code, like `AddAsync`, `ExistsAsync` and so on. It carries `StackExchange.Redis` and usually you can access to it usi the interface `IRedisCacheClient` or `IRedisDatabase.`
+The core package is the library that includes all the method you need into your code, like `AddAsync`, `ExistsAsync` and so on. It carries `StackExchange.Redis` and usually you can access it using the interface `IRedisCacheClient` or `IRedisDatabase.`
 
 ### The Serializer package
 


### PR DESCRIPTION
I was reviewing the library documentation and fixed some typos / spelling mistakes. Please check.