### PR TITLE
Add LoggerFactory & SocketManagerOptions to RedisConfiguration

### DIFF
--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisConnectionPoolManager.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisConnectionPoolManager.cs
@@ -27,10 +27,11 @@ public sealed partial class RedisConnectionPoolManager : IRedisConnectionPoolMan
     /// Initializes a new instance of the <see cref="RedisConnectionPoolManager"/> class.
     /// </summary>
     /// <param name="redisConfiguration">The redis configuration.</param>
-    /// <param name="logger">The logger.</param>
+    /// <param name="logger">The logger. If null will create one from redisConfiguration.LoggerFactory if factory provided</param>
     public RedisConnectionPoolManager(RedisConfiguration redisConfiguration, ILogger<RedisConnectionPoolManager>? logger = null)
     {
         this.redisConfiguration = redisConfiguration ?? throw new ArgumentNullException(nameof(redisConfiguration));
+        logger ??= redisConfiguration.LoggerFactory?.CreateLogger<RedisConnectionPoolManager>();
         this.logger = logger ?? NullLogger<RedisConnectionPoolManager>.Instance;
 
         lock (@lock)


### PR DESCRIPTION
LogerFactory passed to ConnectionMultiplexer and also reused in RedisConnectionPoolManager if loger not provided in constructor.

fix #570