### PR TITLE
Override for Sentinel Commandmap for issue #609 

### DIFF
--- a/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
@@ -36,6 +36,7 @@ public class RedisConfiguration
     private string? configurationChannel;
     private string? connectionString;
     private string? serviceName;
+    private bool disableSentinelCommandmapper;
     private int? connectRetry;
     private SslProtocols? sslProtocols;
     private Func<ProfilingSession>? profilingSessionProvider;
@@ -112,6 +113,20 @@ public class RedisConfiguration
         set
         {
             serviceName = value;
+            ResetConfigurationOptions();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the disableSentinelCommandmapper used in case of Sentinel.
+    /// </summary>
+    public bool DisableSentinelCommandmapper
+    {
+        get => disableSentinelCommandmapper;
+
+        set
+        {
+            disableSentinelCommandmapper = value;
             ResetConfigurationOptions();
         }
     }
@@ -449,7 +464,11 @@ public class RedisConfiguration
                     if (IsSentinelCluster)
                     {
                         newOptions.ServiceName = ServiceName;
-                        newOptions.CommandMap = CommandMap.Sentinel;
+
+                        if (!DisableSentinelCommandmapper)
+                            newOptions.CommandMap = CommandMap.Sentinel;
+                        else
+                            newOptions.CommandMap = CommandMap.SSDB;
                     }
 
                     foreach (var redisHost in Hosts)


### PR DESCRIPTION
There are times we need access to things like the SSDB while using Redis Sentinel. We do not call these connections via `_redisConnectionService` but instead through the `_redisConnectionService.Database` calls. This allows us to have the necessary low level access.

Ideally, when calling `_redisConnectionService.Database` by default we would use SSDB, but that didn't seem like an easy task so this is my quick and dirty attempt at fixing that issue. It may be wrong so let me know