### PR TITLE
Fix configuration defaults, Sentinel CommandMap, AddAllAsync TTL, and add missing properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,7 @@ UpgradeLog*.htm
 # Microsoft Fakes
 FakesAssemblies/
 
+# Claude Code
+CLAUDE.md
+.claude/
+

--- a/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
@@ -140,7 +140,7 @@ public class RedisConfiguration
     }
 
     /// <summary>
-    /// Gets or sets the time in seconds at which to send a heartbeat. A value of -1 means use the default from StackExchange.Redis.
+    /// Gets or sets the time in seconds at which to send a heartbeat. A value of -1 (default) means use the StackExchange.Redis default; 0 disables keepalive.
     /// </summary>
     public int? KeepAlive
     {
@@ -486,7 +486,7 @@ public class RedisConfiguration
                     if (ClientName != null)
                         newOptions.ClientName = ClientName;
 
-                    if (KeepAlive is > 0)
+                    if (KeepAlive is >= 0)
                         newOptions.KeepAlive = KeepAlive.Value;
 
                     if (IsSentinelCluster)

--- a/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Net.Security;
 using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 
 using Microsoft.Extensions.Logging;
 
@@ -25,7 +26,7 @@ public class RedisConfiguration
     private bool allowAdmin;
     private bool ssl;
     private int connectTimeout = 5000;
-    private int syncTimeout = 1000;
+    private int syncTimeout = 5000;
     private bool abortOnConnectFail;
     private int database;
     private RedisHost[] hosts = [];
@@ -36,6 +37,8 @@ public class RedisConfiguration
     private string? configurationChannel;
     private string? connectionString;
     private string? serviceName;
+    private string? clientName;
+    private int? keepAlive = -1;
     private int? connectRetry;
     private SslProtocols? sslProtocols;
     private Func<ProfilingSession>? profilingSessionProvider;
@@ -49,6 +52,12 @@ public class RedisConfiguration
     /// that this cannot be specified in the configuration-string.
     /// </summary>
     public event RemoteCertificateValidationCallback? CertificateValidation;
+
+    /// <summary>
+    /// A LocalCertificateSelectionCallback delegate responsible for selecting the certificate used for authentication; note
+    /// that this cannot be specified in the configuration-string.
+    /// </summary>
+    public event LocalCertificateSelectionCallback? CertificateSelection;
 
     /// <summary>
     /// Indicate if the current configuration is the default;
@@ -112,6 +121,34 @@ public class RedisConfiguration
         set
         {
             serviceName = value;
+            ResetConfigurationOptions();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the client name to use for all connections.
+    /// </summary>
+    public string? ClientName
+    {
+        get => clientName;
+
+        set
+        {
+            clientName = value;
+            ResetConfigurationOptions();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the time in seconds at which to send a heartbeat. A value of -1 means use the default from StackExchange.Redis.
+    /// </summary>
+    public int? KeepAlive
+    {
+        get => keepAlive;
+
+        set
+        {
+            keepAlive = value;
             ResetConfigurationOptions();
         }
     }
@@ -446,6 +483,12 @@ public class RedisConfiguration
                     if (ConnectRetry != null)
                         newOptions.ConnectRetry = ConnectRetry.Value;
 
+                    if (ClientName != null)
+                        newOptions.ClientName = ClientName;
+
+                    if (KeepAlive is > 0)
+                        newOptions.KeepAlive = KeepAlive.Value;
+
                     if (IsSentinelCluster)
                     {
                         newOptions.ServiceName = ServiceName;
@@ -470,6 +513,7 @@ public class RedisConfiguration
                     newOptions.SocketManager = new(GetType().Name, WorkCount, SocketManagerOptions);
 
                 newOptions.CertificateValidation += CertificateValidation;
+                newOptions.CertificateSelection += CertificateSelection;
                 options = newOptions;
             }
 

--- a/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
@@ -490,10 +490,7 @@ public class RedisConfiguration
                         newOptions.KeepAlive = KeepAlive.Value;
 
                     if (IsSentinelCluster)
-                    {
                         newOptions.ServiceName = ServiceName;
-                        newOptions.CommandMap = CommandMap.Sentinel;
-                    }
 
                     foreach (var redisHost in Hosts)
                         newOptions.EndPoints.Add(redisHost.Host, redisHost.Port);

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
@@ -240,6 +240,10 @@ public partial class RedisDatabase : IRedisDatabase
             return false;
 
         var expiration = expiresAt.UtcDateTime.Subtract(DateTime.UtcNow);
+
+        if (expiration <= TimeSpan.Zero)
+            return false;
+
         var db = Database;
         var batch = db.CreateBatch();
 
@@ -249,7 +253,7 @@ public partial class RedisDatabase : IRedisDatabase
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
 
-        return tasks[0].Result;
+        return Array.TrueForAll(tasks, t => t.Result);
     }
 
     /// <inheritdoc/>
@@ -272,7 +276,7 @@ public partial class RedisDatabase : IRedisDatabase
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
 
-        return tasks[0].Result;
+        return Array.TrueForAll(tasks, t => t.Result);
     }
 
     /// <inheritdoc/>

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
@@ -236,9 +236,16 @@ public partial class RedisDatabase : IRedisDatabase
             .Select(x => new KeyValuePair<RedisKey, RedisValue>(x.Key, x.Value))
             .ToArray();
 
-        await Database.StringSetAsync(values, when, flag).ConfigureAwait(false);
+        if (values.Length == 0)
+            return false;
 
-        var tasks = values.ToFastArray(value => Database.KeyExpireAsync(value.Key, expiresAt.UtcDateTime, flag));
+        var expiration = expiresAt.UtcDateTime.Subtract(DateTime.UtcNow);
+        var db = Database;
+        var batch = db.CreateBatch();
+
+        var tasks = values.ToFastArray(v => batch.StringSetAsync(v.Key, v.Value, expiration, when, flag));
+
+        batch.Execute();
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
 
@@ -253,9 +260,15 @@ public partial class RedisDatabase : IRedisDatabase
             .Select(x => new KeyValuePair<RedisKey, RedisValue>(x.Key, x.Value))
             .ToArray();
 
-        await Database.StringSetAsync(values, when, flag).ConfigureAwait(false);
+        if (values.Length == 0)
+            return false;
 
-        var tasks = values.ToFastArray(value => Database.KeyExpireAsync(value.Key, expiresAt, flag));
+        var db = Database;
+        var batch = db.CreateBatch();
+
+        var tasks = values.ToFastArray(v => batch.StringSetAsync(v.Key, v.Value, expiresAt, when, flag));
+
+        batch.Execute();
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
 

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/CacheClientTestBase.cs
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/CacheClientTestBase.cs
@@ -636,6 +636,86 @@ public abstract partial class CacheClientTestBase : IDisposable
     }
 
     [Fact]
+    public async Task AddAllAsync_WithExpiry_EmptyItems_ShouldReturnFalse_Async()
+    {
+        var emptyItems = Array.Empty<Tuple<string, string>>();
+
+        var resultTimeSpan = await Sut.GetDefaultDatabase().AddAllAsync(emptyItems, TimeSpan.FromMinutes(5));
+        var resultDateTimeOffset = await Sut.GetDefaultDatabase().AddAllAsync(emptyItems, DateTimeOffset.UtcNow.AddMinutes(5));
+
+        Assert.False(resultTimeSpan);
+        Assert.False(resultDateTimeOffset);
+    }
+
+    [Fact]
+    public async Task AddAllAsync_WithDateTimeOffsetExpiry_PastDate_ShouldReturnFalse_Async()
+    {
+        var items = new Tuple<string, string>[]
+        {
+            new(Guid.NewGuid().ToString(), "value1"),
+            new(Guid.NewGuid().ToString(), "value2"),
+        };
+
+        var result = await Sut.GetDefaultDatabase().AddAllAsync(items, DateTimeOffset.UtcNow.AddMinutes(-5));
+
+        Assert.False(result);
+
+        foreach (var item in items)
+        {
+            var exists = await Sut.GetDefaultDatabase().ExistsAsync(item.Item1);
+            Assert.False(exists);
+        }
+    }
+
+    [Fact]
+    public async Task AddAllAsync_WithDateTimeOffsetExpiry_ShouldSetTTL_Async()
+    {
+        var key1 = Guid.NewGuid().ToString();
+        var key2 = Guid.NewGuid().ToString();
+        var items = new Tuple<string, string>[]
+        {
+            new(key1, "value1"),
+            new(key2, "value2"),
+        };
+
+        var result = await Sut.GetDefaultDatabase().AddAllAsync(items, DateTimeOffset.UtcNow.AddMinutes(10));
+
+        Assert.True(result);
+
+        var ttl1 = await db.KeyTimeToLiveAsync(key1);
+        var ttl2 = await db.KeyTimeToLiveAsync(key2);
+
+        Assert.NotNull(ttl1);
+        Assert.NotNull(ttl2);
+        Assert.True(ttl1.Value.TotalSeconds > 0);
+        Assert.True(ttl2.Value.TotalSeconds > 0);
+    }
+
+    [Fact]
+    public async Task AddAllAsync_WithTimeSpanExpiry_ShouldSetTTL_Async()
+    {
+        var key1 = Guid.NewGuid().ToString();
+        var key2 = Guid.NewGuid().ToString();
+        var items = new Tuple<string, string>[]
+        {
+            new(key1, "value1"),
+            new(key2, "value2"),
+        };
+
+        var result = await Sut.GetDefaultDatabase().AddAllAsync(items, TimeSpan.FromMinutes(10));
+
+        Assert.True(result);
+
+        var ttl1 = await db.KeyTimeToLiveAsync(key1);
+        var ttl2 = await db.KeyTimeToLiveAsync(key2);
+
+        Assert.NotNull(ttl1);
+        Assert.NotNull(ttl2);
+        Assert.True(ttl1.Value.TotalSeconds > 0);
+        Assert.True(ttl2.Value.TotalSeconds > 0);
+    }
+
+    [Fact]
     public async Task Adding_Collection_To_Redis_Should_Work_Correctly_Async()
     {
         var items = Range(1, 3).Select(i => new TestClass<string> { Key = $"key{i.ToString(CultureInfo.InvariantCulture)}", Value = $"value{i.ToString(CultureInfo.InvariantCulture)}" }).ToArray();


### PR DESCRIPTION
## Summary

### Configuration fixes
- **Fix default `SyncTimeout`** from 1000ms to 5000ms to match the XML documentation and StackExchange.Redis defaults (fixes #608)
- **Fix Sentinel `CommandMap`**: remove `CommandMap.Sentinel` from Sentinel configuration. When using `ConnectionMultiplexer.Connect()` with `ServiceName`, SE.Redis handles the Sentinel protocol internally — the `CommandMap` was incorrectly applied to the resolved master connection, disabling all data commands including EVAL, GET, SET, SCAN (fixes #609)

### Bug fixes
- **Fix `AddAllAsync` TTL race condition**: replaced the two-phase `MSET` + N×`EXPIREAT` approach with batched `SET` commands using inline expiration (`SET key value PX <ms>`). The previous approach had a race window where keys existed without TTL between the MSET and EXPIREAT calls (fixes #615)
- **Fix empty items edge case** in `AddAllAsync` with expiry that previously caused `IndexOutOfRangeException`

### New RedisConfiguration properties
- **Add `CertificateSelection` event** for TLS client certificate authentication (fixes #613)
- **Add `ClientName` property** for setting the Redis connection client name (fixes #595)
- **Add `KeepAlive` property** for heartbeat interval configuration (fixes #496)

### Misc
- Add `CLAUDE.md` and `.claude/` to `.gitignore`

## Test plan

- [ ] Verify `SyncTimeout` defaults to 5000ms when not explicitly set
- [ ] Verify Sentinel configuration no longer blocks EVAL and other data commands
- [ ] Verify `AddAllAsync` with expiry sets TTL atomically on all keys
- [ ] Verify `AddAllAsync` with empty items array returns `false` without throwing
- [ ] Verify `CertificateSelection` callback is invoked during TLS handshake
- [ ] Verify `ClientName` appears in Redis `CLIENT LIST` output
- [ ] Verify `KeepAlive` is forwarded to `ConfigurationOptions`
- [ ] Existing tests pass without modification