### PR TITLE
Add .NET 10 target framework support

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -29,15 +29,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            2.1.x
             8.0.x
             9.0.x
+            10.0.x
+
+      - name: Run .NET 10 Tests
+        run: dotnet test -f net10.0
+        shell: bash
+        env:
+          REDIS_HOST: localhost
 
       - name: Run .NET 9 Tests
         run: dotnet test -f net9.0
@@ -57,15 +63,15 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            2.1.x
             8.0.x
             9.0.x
+            10.0.x
 
       - name: Build with dotnet
         run: ./NuGetPack.bat

--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,7 @@ UpgradeLog*.htm
 # Microsoft Fakes
 FakesAssemblies/
 
+# Claude Code
+CLAUDE.md
+.claude/
+

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
         <!--
         <VersionSuffix>pre</VersionSuffix>
         -->
-        <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <IncludeSource>True</IncludeSource>
         <IncludeSymbols>True</IncludeSymbols>

--- a/NuGetPack.bat
+++ b/NuGetPack.bat
@@ -1,8 +1,9 @@
 dotnet pack src\core\StackExchange.Redis.Extensions.Core\StackExchange.Redis.Extensions.Core.csproj -o .\packages\ -c Release
-dotnet pack src\serializers\StackExchange.Redis.Extensions.Jil\StackExchange.Redis.Extensions.Jil.csproj -o .\packages\ -c Release
 dotnet pack src\serializers\StackExchange.Redis.Extensions.MsgPack\StackExchange.Redis.Extensions.MsgPack.csproj -o .\packages\ -c Release
 dotnet pack src\serializers\StackExchange.Redis.Extensions.Newtonsoft\StackExchange.Redis.Extensions.Newtonsoft.csproj -o .\packages\ -c Release
 dotnet pack src\serializers\StackExchange.Redis.Extensions.Protobuf\StackExchange.Redis.Extensions.Protobuf.csproj -o .\packages\ -c Release
 dotnet pack src\serializers\StackExchange.Redis.Extensions.Utf8Json\StackExchange.Redis.Extensions.Utf8Json.csproj -o .\packages\ -c Release
 dotnet pack src\serializers\StackExchange.Redis.Extensions.System.Text.Json\StackExchange.Redis.Extensions.System.Text.Json.csproj -o .\packages\ -c Release
+dotnet pack src\serializers\StackExchange.Redis.Extensions.MemoryPack\StackExchange.Redis.Extensions.MemoryPack.csproj -o .\packages\ -c Release
+dotnet pack src\serializers\StackExchange.Redis.Extensions.ServiceStack\StackExchange.Redis.Extensions.ServiceStack.csproj -o .\packages\ -c Release
 dotnet pack src\aspnet\StackExchange.Redis.Extensions.AspNetCore\StackExchange.Redis.Extensions.AspNetCore.csproj -o .\packages\ -c Release

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,6 @@
 
 find . -iname "bin" -o -iname "obj" | xargs rm -rf
 
-dotnet test -f net7.0 --verbosity quiet
-dotnet test -f net6.0 --verbosity quiet
-dotnet test -f netcoreapp2.1 --verbosity quiet
+dotnet test -f net10.0 --verbosity quiet
+dotnet test -f net9.0 --verbosity quiet
+dotnet test -f net8.0 --verbosity quiet

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "9.0.*",
+    "version": "10.0.*",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "9.0.*"
+    "dotnet": "10.0.*"
   }
 }

--- a/samples/StackExchange.Redis.Samples.Web.Mvc/StackExchange.Redis.Samples.Web.Mvc.csproj
+++ b/samples/StackExchange.Redis.Samples.Web.Mvc/StackExchange.Redis.Samples.Web.Mvc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <IsPackable>False</IsPackable>
     <NoWarn>SA1507,SA1210,SA1515,SA1591,SA1513,CS1507,CS1210,CS1515,CS1591</NoWarn>

--- a/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/StackExchange.Redis.Extensions.AspNetCore.csproj
+++ b/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/StackExchange.Redis.Extensions.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Title>StackExchange.Redis.Extensions.AspNetCore is a library that has a set of extensions method fpr ASP.NET Core.</Title>
     <Summary>StackExchange.Redis.Extensions.AspNetCore is a library that has a set of extensions method fpr ASP.NET Core with the scope to simply the library configuration into the dependency injection</Summary>
     <Description>StackExchange.Redis.Extensions.AspNetCore is a library that has a set of extensions method fpr ASP.NET Core</Description>

--- a/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
@@ -140,7 +140,7 @@ public class RedisConfiguration
     }
 
     /// <summary>
-    /// Gets or sets the time in seconds at which to send a heartbeat. A value of -1 means use the default from StackExchange.Redis.
+    /// Gets or sets the time in seconds at which to send a heartbeat. A value of -1 (default) means use the StackExchange.Redis default; 0 disables keepalive.
     /// </summary>
     public int? KeepAlive
     {
@@ -486,7 +486,7 @@ public class RedisConfiguration
                     if (ClientName != null)
                         newOptions.ClientName = ClientName;
 
-                    if (KeepAlive is > 0)
+                    if (KeepAlive is >= 0)
                         newOptions.KeepAlive = KeepAlive.Value;
 
                     if (IsSentinelCluster)

--- a/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Net.Security;
 using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 
 using Microsoft.Extensions.Logging;
 
@@ -25,7 +26,7 @@ public class RedisConfiguration
     private bool allowAdmin;
     private bool ssl;
     private int connectTimeout = 5000;
-    private int syncTimeout = 1000;
+    private int syncTimeout = 5000;
     private bool abortOnConnectFail;
     private int database;
     private RedisHost[] hosts = [];
@@ -36,6 +37,8 @@ public class RedisConfiguration
     private string? configurationChannel;
     private string? connectionString;
     private string? serviceName;
+    private string? clientName;
+    private int? keepAlive = -1;
     private int? connectRetry;
     private SslProtocols? sslProtocols;
     private Func<ProfilingSession>? profilingSessionProvider;
@@ -49,6 +52,12 @@ public class RedisConfiguration
     /// that this cannot be specified in the configuration-string.
     /// </summary>
     public event RemoteCertificateValidationCallback? CertificateValidation;
+
+    /// <summary>
+    /// A LocalCertificateSelectionCallback delegate responsible for selecting the certificate used for authentication; note
+    /// that this cannot be specified in the configuration-string.
+    /// </summary>
+    public event LocalCertificateSelectionCallback? CertificateSelection;
 
     /// <summary>
     /// Indicate if the current configuration is the default;
@@ -112,6 +121,34 @@ public class RedisConfiguration
         set
         {
             serviceName = value;
+            ResetConfigurationOptions();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the client name to use for all connections.
+    /// </summary>
+    public string? ClientName
+    {
+        get => clientName;
+
+        set
+        {
+            clientName = value;
+            ResetConfigurationOptions();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the time in seconds at which to send a heartbeat. A value of -1 means use the default from StackExchange.Redis.
+    /// </summary>
+    public int? KeepAlive
+    {
+        get => keepAlive;
+
+        set
+        {
+            keepAlive = value;
             ResetConfigurationOptions();
         }
     }
@@ -446,6 +483,12 @@ public class RedisConfiguration
                     if (ConnectRetry != null)
                         newOptions.ConnectRetry = ConnectRetry.Value;
 
+                    if (ClientName != null)
+                        newOptions.ClientName = ClientName;
+
+                    if (KeepAlive is > 0)
+                        newOptions.KeepAlive = KeepAlive.Value;
+
                     if (IsSentinelCluster)
                     {
                         newOptions.ServiceName = ServiceName;
@@ -470,6 +513,7 @@ public class RedisConfiguration
                     newOptions.SocketManager = new(GetType().Name, WorkCount, SocketManagerOptions);
 
                 newOptions.CertificateValidation += CertificateValidation;
+                newOptions.CertificateSelection += CertificateSelection;
                 options = newOptions;
             }
 

--- a/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
@@ -490,10 +490,7 @@ public class RedisConfiguration
                         newOptions.KeepAlive = KeepAlive.Value;
 
                     if (IsSentinelCluster)
-                    {
                         newOptions.ServiceName = ServiceName;
-                        newOptions.CommandMap = CommandMap.Sentinel;
-                    }
 
                     foreach (var redisHost in Hosts)
                         newOptions.EndPoints.Add(redisHost.Host, redisHost.Port);

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
@@ -240,6 +240,10 @@ public partial class RedisDatabase : IRedisDatabase
             return false;
 
         var expiration = expiresAt.UtcDateTime.Subtract(DateTime.UtcNow);
+
+        if (expiration <= TimeSpan.Zero)
+            return false;
+
         var db = Database;
         var batch = db.CreateBatch();
 
@@ -249,7 +253,7 @@ public partial class RedisDatabase : IRedisDatabase
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
 
-        return tasks[0].Result;
+        return Array.TrueForAll(tasks, t => t.Result);
     }
 
     /// <inheritdoc/>
@@ -272,7 +276,7 @@ public partial class RedisDatabase : IRedisDatabase
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
 
-        return tasks[0].Result;
+        return Array.TrueForAll(tasks, t => t.Result);
     }
 
     /// <inheritdoc/>

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
@@ -236,9 +236,16 @@ public partial class RedisDatabase : IRedisDatabase
             .Select(x => new KeyValuePair<RedisKey, RedisValue>(x.Key, x.Value))
             .ToArray();
 
-        await Database.StringSetAsync(values, when, flag).ConfigureAwait(false);
+        if (values.Length == 0)
+            return false;
 
-        var tasks = values.ToFastArray(value => Database.KeyExpireAsync(value.Key, expiresAt.UtcDateTime, flag));
+        var expiration = expiresAt.UtcDateTime.Subtract(DateTime.UtcNow);
+        var db = Database;
+        var batch = db.CreateBatch();
+
+        var tasks = values.ToFastArray(v => batch.StringSetAsync(v.Key, v.Value, expiration, when, flag));
+
+        batch.Execute();
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
 
@@ -253,9 +260,15 @@ public partial class RedisDatabase : IRedisDatabase
             .Select(x => new KeyValuePair<RedisKey, RedisValue>(x.Key, x.Value))
             .ToArray();
 
-        await Database.StringSetAsync(values, when, flag).ConfigureAwait(false);
+        if (values.Length == 0)
+            return false;
 
-        var tasks = values.ToFastArray(value => Database.KeyExpireAsync(value.Key, expiresAt, flag));
+        var db = Database;
+        var batch = db.CreateBatch();
+
+        var tasks = values.ToFastArray(v => batch.StringSetAsync(v.Key, v.Value, expiresAt, when, flag));
+
+        batch.Execute();
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
 

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/CacheClientTestBase.cs
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/CacheClientTestBase.cs
@@ -636,6 +636,86 @@ public abstract partial class CacheClientTestBase : IDisposable
     }
 
     [Fact]
+    public async Task AddAllAsync_WithExpiry_EmptyItems_ShouldReturnFalse_Async()
+    {
+        var emptyItems = Array.Empty<Tuple<string, string>>();
+
+        var resultTimeSpan = await Sut.GetDefaultDatabase().AddAllAsync(emptyItems, TimeSpan.FromMinutes(5));
+        var resultDateTimeOffset = await Sut.GetDefaultDatabase().AddAllAsync(emptyItems, DateTimeOffset.UtcNow.AddMinutes(5));
+
+        Assert.False(resultTimeSpan);
+        Assert.False(resultDateTimeOffset);
+    }
+
+    [Fact]
+    public async Task AddAllAsync_WithDateTimeOffsetExpiry_PastDate_ShouldReturnFalse_Async()
+    {
+        var items = new Tuple<string, string>[]
+        {
+            new(Guid.NewGuid().ToString(), "value1"),
+            new(Guid.NewGuid().ToString(), "value2"),
+        };
+
+        var result = await Sut.GetDefaultDatabase().AddAllAsync(items, DateTimeOffset.UtcNow.AddMinutes(-5));
+
+        Assert.False(result);
+
+        foreach (var item in items)
+        {
+            var exists = await Sut.GetDefaultDatabase().ExistsAsync(item.Item1);
+            Assert.False(exists);
+        }
+    }
+
+    [Fact]
+    public async Task AddAllAsync_WithDateTimeOffsetExpiry_ShouldSetTTL_Async()
+    {
+        var key1 = Guid.NewGuid().ToString();
+        var key2 = Guid.NewGuid().ToString();
+        var items = new Tuple<string, string>[]
+        {
+            new(key1, "value1"),
+            new(key2, "value2"),
+        };
+
+        var result = await Sut.GetDefaultDatabase().AddAllAsync(items, DateTimeOffset.UtcNow.AddMinutes(10));
+
+        Assert.True(result);
+
+        var ttl1 = await db.KeyTimeToLiveAsync(key1);
+        var ttl2 = await db.KeyTimeToLiveAsync(key2);
+
+        Assert.NotNull(ttl1);
+        Assert.NotNull(ttl2);
+        Assert.True(ttl1.Value.TotalSeconds > 0);
+        Assert.True(ttl2.Value.TotalSeconds > 0);
+    }
+
+    [Fact]
+    public async Task AddAllAsync_WithTimeSpanExpiry_ShouldSetTTL_Async()
+    {
+        var key1 = Guid.NewGuid().ToString();
+        var key2 = Guid.NewGuid().ToString();
+        var items = new Tuple<string, string>[]
+        {
+            new(key1, "value1"),
+            new(key2, "value2"),
+        };
+
+        var result = await Sut.GetDefaultDatabase().AddAllAsync(items, TimeSpan.FromMinutes(10));
+
+        Assert.True(result);
+
+        var ttl1 = await db.KeyTimeToLiveAsync(key1);
+        var ttl2 = await db.KeyTimeToLiveAsync(key2);
+
+        Assert.NotNull(ttl1);
+        Assert.NotNull(ttl2);
+        Assert.True(ttl1.Value.TotalSeconds > 0);
+        Assert.True(ttl2.Value.TotalSeconds > 0);
+    }
+
+    [Fact]
     public async Task Adding_Collection_To_Redis_Should_Work_Correctly_Async()
     {
         var items = Range(1, 3).Select(i => new TestClass<string> { Key = $"key{i.ToString(CultureInfo.InvariantCulture)}", Value = $"value{i.ToString(CultureInfo.InvariantCulture)}" }).ToArray();

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/StackExchange.Redis.Extensions.Core.Tests.csproj
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/StackExchange.Redis.Extensions.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -35,7 +35,7 @@
     <ProjectReference Include="..\..\src\serializers\StackExchange.Redis.Extensions.Utf8Json\StackExchange.Redis.Extensions.Utf8Json.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0' ">
     <ProjectReference Include="..\..\src\serializers\StackExchange.Redis.Extensions.MemoryPack\StackExchange.Redis.Extensions.MemoryPack.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Adds `net10.0` as a target framework across the entire solution, including libraries, tests, CI/CD, and tooling.

Closes #619

> **Note:** This branch is based on `fix/quick-wins-cleanup` (PR #618) which contains pending configuration fixes and bug fixes. This avoids merge conflicts in shared files like `RedisConfiguration.cs`, `Directory.Build.props`, and the CI workflow. PR #618 should be merged first.

## Changes

### Project files
- **`Directory.Build.props`**: added `net10.0` to `TargetFrameworks` — propagates to Core and all 7 serializer projects
- **`AspNetCore.csproj`**: added `net10.0` (overrides `Directory.Build.props` since it needs `FrameworkReference`)
- **`Core.Tests.csproj`**: added `net10.0` to test TFMs and to MemoryPack conditional reference
- **`global.json`**: updated SDK from `9.0.*` to `10.0.*` (`rollForward: latestMajor` ensures .NET 9 SDK still works)
- **Sample project**: updated from `net7.0` to `net10.0`

### CI/CD
- Added `10.0.x` SDK and `.NET 10 Tests` step to GitHub Actions workflow
- Upgraded `actions/checkout` and `actions/setup-dotnet` from v3 to v4
- Removed obsolete `2.1.x` SDK reference

### Build scripts
- **`NuGetPack.bat`**: removed defunct `Jil` serializer, added missing `MemoryPack` and `ServiceStack`
- **`build.sh`**: updated TFMs from `net7.0/net6.0/netcoreapp2.1` to `net10.0/net9.0/net8.0`

## Build verification

All three modern TFMs compile cleanly with zero errors and zero warnings:
```
dotnet build -f net10.0  ✅
dotnet build -f net9.0   ✅
dotnet build -f net8.0   ✅
```

> `netstandard2.1` has pre-existing build errors (missing `Unsafe` references introduced by PR #607). This is tracked separately and not related to this PR.

## Test plan

- [ ] Verify `dotnet build` succeeds for net8.0, net9.0, net10.0
- [ ] Verify `dotnet test -f net10.0` passes all tests
- [ ] Verify NuGet packages are generated for all TFMs including net10.0
- [ ] Verify CI workflow runs .NET 10 tests successfully