### PR TITLE
Add GeoSpatial and Redis Streams support

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -29,15 +29,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            2.1.x
             8.0.x
             9.0.x
+            10.0.x
+
+      - name: Run .NET 10 Tests
+        run: dotnet test -f net10.0
+        shell: bash
+        env:
+          REDIS_HOST: localhost
 
       - name: Run .NET 9 Tests
         run: dotnet test -f net9.0
@@ -57,15 +63,15 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            2.1.x
             8.0.x
             9.0.x
+            10.0.x
 
       - name: Build with dotnet
         run: ./NuGetPack.bat

--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,7 @@ UpgradeLog*.htm
 # Microsoft Fakes
 FakesAssemblies/
 
+# Claude Code
+CLAUDE.md
+.claude/
+

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
         <!--
         <VersionSuffix>pre</VersionSuffix>
         -->
-        <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <IncludeSource>True</IncludeSource>
         <IncludeSymbols>True</IncludeSymbols>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <!-- General information -->
     <PropertyGroup>
         <Authors>Ugo Lattanzi</Authors>
-        <VersionPrefix>11.0.0</VersionPrefix>
+        <VersionPrefix>12.0.0</VersionPrefix>
         <!--
         <VersionSuffix>pre</VersionSuffix>
         -->
@@ -116,32 +116,32 @@
                           IncludeAssets="runtime; build; native; contentfiles; analyzer"/>
 
         <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers"
-                          Version="17.12.*"
+                          Version="[17.14.*,18.0.0)"
                           PrivateAssets="all"
                           IncludeAssets="runtime; build; native; contentfiles; analyzer"/>
 
         <PackageReference Include="Roslynator.Analyzers"
-                          Version="[4.12.*,5.0)"
+                          Version="[4.15.*,5.0)"
                           PrivateAssets="all"
                           IncludeAssets="runtime; build; native; contentfiles; analyzer"/>
 
         <PackageReference Include="Roslynator.CodeAnalysis.Analyzers"
-                          Version="[4.12.*,5.0)"
+                          Version="[4.15.*,5.0)"
                           PrivateAssets="all"
                           IncludeAssets="runtime; build; native; contentfiles; analyzer"/>
 
         <PackageReference Include="Roslynator.Formatting.Analyzers"
-                          Version="[4.12.*,5.0)"
+                          Version="[4.15.*,5.0)"
                           PrivateAssets="all"
                           IncludeAssets="runtime; build; native; contentfiles; analyzer"/>
 
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers"
-                          Version="[3.11.*,4.0)"
+                          Version="[5.3.*,6.0)"
                           PrivateAssets="all"
                           IncludeAssets="runtime; build; native; contentfiles; analyzer"/>
 
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp"
-                          Version="4.12.0"
+                          Version="[5.3.*,6.0)"
                           PrivateAssets="all"
                           IncludeAssets="runtime; build; native; contentfiles; analyzer"/>
     </ItemGroup>

--- a/NuGetPack.bat
+++ b/NuGetPack.bat
@@ -1,8 +1,9 @@
 dotnet pack src\core\StackExchange.Redis.Extensions.Core\StackExchange.Redis.Extensions.Core.csproj -o .\packages\ -c Release
-dotnet pack src\serializers\StackExchange.Redis.Extensions.Jil\StackExchange.Redis.Extensions.Jil.csproj -o .\packages\ -c Release
 dotnet pack src\serializers\StackExchange.Redis.Extensions.MsgPack\StackExchange.Redis.Extensions.MsgPack.csproj -o .\packages\ -c Release
 dotnet pack src\serializers\StackExchange.Redis.Extensions.Newtonsoft\StackExchange.Redis.Extensions.Newtonsoft.csproj -o .\packages\ -c Release
 dotnet pack src\serializers\StackExchange.Redis.Extensions.Protobuf\StackExchange.Redis.Extensions.Protobuf.csproj -o .\packages\ -c Release
 dotnet pack src\serializers\StackExchange.Redis.Extensions.Utf8Json\StackExchange.Redis.Extensions.Utf8Json.csproj -o .\packages\ -c Release
 dotnet pack src\serializers\StackExchange.Redis.Extensions.System.Text.Json\StackExchange.Redis.Extensions.System.Text.Json.csproj -o .\packages\ -c Release
+dotnet pack src\serializers\StackExchange.Redis.Extensions.MemoryPack\StackExchange.Redis.Extensions.MemoryPack.csproj -o .\packages\ -c Release
+dotnet pack src\serializers\StackExchange.Redis.Extensions.ServiceStack\StackExchange.Redis.Extensions.ServiceStack.csproj -o .\packages\ -c Release
 dotnet pack src\aspnet\StackExchange.Redis.Extensions.AspNetCore\StackExchange.Redis.Extensions.AspNetCore.csproj -o .\packages\ -c Release

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,6 @@
 
 find . -iname "bin" -o -iname "obj" | xargs rm -rf
 
-dotnet test -f net7.0 --verbosity quiet
-dotnet test -f net6.0 --verbosity quiet
-dotnet test -f netcoreapp2.1 --verbosity quiet
+dotnet test -f net10.0 --verbosity quiet
+dotnet test -f net9.0 --verbosity quiet
+dotnet test -f net8.0 --verbosity quiet

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "9.0.*",
+    "version": "10.0.*",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "9.0.*"
+    "dotnet": "10.0.*"
   }
 }

--- a/samples/StackExchange.Redis.Samples.Web.Mvc/StackExchange.Redis.Samples.Web.Mvc.csproj
+++ b/samples/StackExchange.Redis.Samples.Web.Mvc/StackExchange.Redis.Samples.Web.Mvc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <IsPackable>False</IsPackable>
     <NoWarn>SA1507,SA1210,SA1515,SA1591,SA1513,CS1507,CS1210,CS1515,CS1591</NoWarn>

--- a/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/StackExchange.Redis.Extensions.AspNetCore.csproj
+++ b/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/StackExchange.Redis.Extensions.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Title>StackExchange.Redis.Extensions.AspNetCore is a library that has a set of extensions method fpr ASP.NET Core.</Title>
     <Summary>StackExchange.Redis.Extensions.AspNetCore is a library that has a set of extensions method fpr ASP.NET Core with the scope to simply the library configuration into the dependency injection</Summary>
     <Description>StackExchange.Redis.Extensions.AspNetCore is a library that has a set of extensions method fpr ASP.NET Core</Description>

--- a/src/core/StackExchange.Redis.Extensions.Core/Abstractions/IRedisDatabase.Geo.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Abstractions/IRedisDatabase.Geo.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace StackExchange.Redis.Extensions.Core.Abstractions;
+
+/// <summary>
+/// The Redis Database Geo extensions
+/// </summary>
+public partial interface IRedisDatabase
+{
+    /// <summary>
+    ///     Add the specified member to the geospatial index stored at key.
+    /// </summary>
+    /// <param name="key">The key of the set.</param>
+    /// <param name="longitude">The longitude of the geo entry.</param>
+    /// <param name="latitude">The latitude of the geo entry.</param>
+    /// <param name="member">The name to assign to this entry.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>True if the member was added, false if it already existed and was updated.</returns>
+    Task<bool> GeoAddAsync(string key, double longitude, double latitude, string member, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Add one geo entry to the geospatial index stored at key.
+    /// </summary>
+    /// <param name="key">The key of the set.</param>
+    /// <param name="value">The geo entry to store.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>True if the member was added, false if it already existed and was updated.</returns>
+    Task<bool> GeoAddAsync(string key, GeoEntry value, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Add multiple geo entries to the geospatial index stored at key.
+    /// </summary>
+    /// <param name="key">The key of the set.</param>
+    /// <param name="values">The geo entries to add.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The number of elements added (not including updates to existing members).</returns>
+    Task<long> GeoAddAsync(string key, GeoEntry[] values, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Removes the specified member from the geospatial index stored at key.
+    /// </summary>
+    /// <param name="key">The key of the set.</param>
+    /// <param name="member">The member to remove.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>True if the member existed and was removed, otherwise false.</returns>
+    Task<bool> GeoRemoveAsync(string key, string member, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns the distance between two members in the geospatial index.
+    /// </summary>
+    /// <param name="key">The key of the set.</param>
+    /// <param name="member1">The first member.</param>
+    /// <param name="member2">The second member.</param>
+    /// <param name="unit">The unit of distance to return.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The distance in the specified unit, or null if either member is missing.</returns>
+    Task<double?> GeoDistanceAsync(string key, string member1, string member2, GeoUnit unit = GeoUnit.Meters, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns the geohash string of a single member in the geospatial index.
+    /// </summary>
+    /// <param name="key">The key of the set.</param>
+    /// <param name="member">The member to retrieve.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The geohash string, or null if the member does not exist.</returns>
+    Task<string?> GeoHashAsync(string key, string member, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns the geohash strings for multiple members in the geospatial index.
+    /// </summary>
+    /// <param name="key">The key of the set.</param>
+    /// <param name="members">The members to retrieve.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>An array of geohash strings, with null entries for missing members.</returns>
+    Task<string?[]> GeoHashAsync(string key, string[] members, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns the longitude and latitude of a single member in the geospatial index.
+    /// </summary>
+    /// <param name="key">The key of the set.</param>
+    /// <param name="member">The member to retrieve.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The position, or null if the member does not exist.</returns>
+    Task<GeoPosition?> GeoPositionAsync(string key, string member, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns the longitude and latitude of multiple members in the geospatial index.
+    /// </summary>
+    /// <param name="key">The key of the set.</param>
+    /// <param name="members">The members to retrieve.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>An array of positions, with null entries for missing members.</returns>
+    Task<GeoPosition?[]> GeoPositionAsync(string key, string[] members, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns members within the specified radius of a given member.
+    /// </summary>
+    /// <param name="key">The key of the set.</param>
+    /// <param name="member">The member to use as the center point.</param>
+    /// <param name="radius">The radius to search within.</param>
+    /// <param name="unit">The unit of the radius.</param>
+    /// <param name="count">The maximum number of results, -1 for unlimited.</param>
+    /// <param name="order">The order in which to return results.</param>
+    /// <param name="options">Options controlling which data to include in results.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The matching results.</returns>
+    Task<GeoRadiusResult[]> GeoRadiusAsync(string key, string member, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns members within the specified radius of a given longitude/latitude coordinate.
+    /// </summary>
+    /// <param name="key">The key of the set.</param>
+    /// <param name="longitude">The longitude of the center point.</param>
+    /// <param name="latitude">The latitude of the center point.</param>
+    /// <param name="radius">The radius to search within.</param>
+    /// <param name="unit">The unit of the radius.</param>
+    /// <param name="count">The maximum number of results, -1 for unlimited.</param>
+    /// <param name="order">The order in which to return results.</param>
+    /// <param name="options">Options controlling which data to include in results.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The matching results.</returns>
+    Task<GeoRadiusResult[]> GeoRadiusAsync(string key, double longitude, double latitude, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns members of the geospatial index bounded by the provided shape, centered on a given member.
+    /// </summary>
+    /// <param name="key">The key of the set.</param>
+    /// <param name="member">The set member to use as the center of the shape.</param>
+    /// <param name="shape">The shape bounding the search (use GeoSearchCircle or GeoSearchBox).</param>
+    /// <param name="count">The maximum number of results, -1 for unlimited.</param>
+    /// <param name="demandClosest">When true, terminates early once count results are found.</param>
+    /// <param name="order">The order in which to return results.</param>
+    /// <param name="options">Options controlling which data to include in results.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The matching results.</returns>
+    Task<GeoRadiusResult[]> GeoSearchAsync(string key, string member, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns members of the geospatial index bounded by the provided shape, centered on a given coordinate.
+    /// </summary>
+    /// <param name="key">The key of the set.</param>
+    /// <param name="longitude">The longitude of the center point.</param>
+    /// <param name="latitude">The latitude of the center point.</param>
+    /// <param name="shape">The shape bounding the search (use GeoSearchCircle or GeoSearchBox).</param>
+    /// <param name="count">The maximum number of results, -1 for unlimited.</param>
+    /// <param name="demandClosest">When true, terminates early once count results are found.</param>
+    /// <param name="order">The order in which to return results.</param>
+    /// <param name="options">Options controlling which data to include in results.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The matching results.</returns>
+    Task<GeoRadiusResult[]> GeoSearchAsync(string key, double longitude, double latitude, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Searches the geospatial index and stores the results in a destination key, centered on a given member.
+    /// </summary>
+    /// <param name="sourceKey">The key of the source set.</param>
+    /// <param name="destinationKey">The key to store the results at.</param>
+    /// <param name="member">The set member to use as the center of the shape.</param>
+    /// <param name="shape">The shape bounding the search.</param>
+    /// <param name="count">The maximum number of results, -1 for unlimited.</param>
+    /// <param name="demandClosest">When true, terminates early once count results are found.</param>
+    /// <param name="order">The order in which to store results.</param>
+    /// <param name="storeDistances">When true, the destination is a plain sorted set of distances rather than a geo-encoded set.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The number of elements stored in the destination key.</returns>
+    Task<long> GeoSearchAndStoreAsync(string sourceKey, string destinationKey, string member, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, bool storeDistances = false, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Searches the geospatial index and stores the results in a destination key, centered on a given coordinate.
+    /// </summary>
+    /// <param name="sourceKey">The key of the source set.</param>
+    /// <param name="destinationKey">The key to store the results at.</param>
+    /// <param name="longitude">The longitude of the center point.</param>
+    /// <param name="latitude">The latitude of the center point.</param>
+    /// <param name="shape">The shape bounding the search.</param>
+    /// <param name="count">The maximum number of results, -1 for unlimited.</param>
+    /// <param name="demandClosest">When true, terminates early once count results are found.</param>
+    /// <param name="order">The order in which to store results.</param>
+    /// <param name="storeDistances">When true, the destination is a plain sorted set of distances rather than a geo-encoded set.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The number of elements stored in the destination key.</returns>
+    Task<long> GeoSearchAndStoreAsync(string sourceKey, string destinationKey, double longitude, double latitude, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, bool storeDistances = false, CommandFlags flag = CommandFlags.None);
+}

--- a/src/core/StackExchange.Redis.Extensions.Core/Abstractions/IRedisDatabase.Streams.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Abstractions/IRedisDatabase.Streams.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace StackExchange.Redis.Extensions.Core.Abstractions;
+
+/// <summary>
+/// The Redis Database Streams extensions
+/// </summary>
+public partial interface IRedisDatabase
+{
+    /// <summary>
+    ///     Appends a serialized entry to a stream using a single named field.
+    ///     The value is serialized using the configured <see cref="ISerializer"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to serialize.</typeparam>
+    /// <param name="key">The key of the stream.</param>
+    /// <param name="fieldName">The field name within the stream entry.</param>
+    /// <param name="value">The value to serialize and store.</param>
+    /// <param name="messageId">The id to assign to the message, or null for auto-generation.</param>
+    /// <param name="maxLength">The approximate maximum length of the stream, or null for no limit.</param>
+    /// <param name="useApproximateMaxLength">If true, allows the stream to exceed maxLength slightly for performance.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The id of the added message.</returns>
+    Task<RedisValue> StreamAddAsync<T>(string key, string fieldName, T value, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Appends a multi-field entry to a stream.
+    /// </summary>
+    /// <param name="key">The key of the stream.</param>
+    /// <param name="entries">The field-value pairs to store in the stream entry.</param>
+    /// <param name="messageId">The id to assign to the message, or null for auto-generation.</param>
+    /// <param name="maxLength">The approximate maximum length of the stream, or null for no limit.</param>
+    /// <param name="useApproximateMaxLength">If true, allows the stream to exceed maxLength slightly for performance.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The id of the added message.</returns>
+    Task<RedisValue> StreamAddAsync(string key, NameValueEntry[] entries, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns the number of entries in a stream.
+    /// </summary>
+    /// <param name="key">The key of the stream.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The number of entries in the stream, or 0 if the key does not exist.</returns>
+    Task<long> StreamLengthAsync(string key, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Trims a stream to a specified maximum length.
+    /// </summary>
+    /// <param name="key">The key of the stream.</param>
+    /// <param name="maxLength">The maximum length of the stream after trimming.</param>
+    /// <param name="useApproximateMaxLength">If true, allows slightly more entries for performance.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The number of entries removed from the stream.</returns>
+    Task<long> StreamTrimAsync(string key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Deletes entries from a stream by their message IDs.
+    /// </summary>
+    /// <param name="key">The key of the stream.</param>
+    /// <param name="messageIds">The IDs of the messages to delete.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The number of entries deleted.</returns>
+    Task<long> StreamDeleteAsync(string key, string[] messageIds, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns a range of entries from a stream.
+    /// </summary>
+    /// <param name="key">The key of the stream.</param>
+    /// <param name="minId">The minimum message ID, or null for the beginning.</param>
+    /// <param name="maxId">The maximum message ID, or null for the end.</param>
+    /// <param name="count">The maximum number of entries to return, or null for all.</param>
+    /// <param name="messageOrder">The order to return messages (ascending or descending).</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The stream entries in the requested range.</returns>
+    Task<StreamEntry[]> StreamRangeAsync(string key, RedisValue? minId = null, RedisValue? maxId = null, int? count = null, Order messageOrder = Order.Ascending, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Reads entries from a stream starting at the given position.
+    /// </summary>
+    /// <param name="key">The key of the stream.</param>
+    /// <param name="position">The position to read from (e.g. "0-0" for the beginning, or a specific message ID).</param>
+    /// <param name="count">The maximum number of entries to return, or null for all.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The stream entries read.</returns>
+    Task<StreamEntry[]> StreamReadAsync(string key, RedisValue position, int? count = null, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Creates a consumer group for the specified stream.
+    /// </summary>
+    /// <param name="key">The key of the stream.</param>
+    /// <param name="groupName">The name of the consumer group to create.</param>
+    /// <param name="position">The position in the stream to start reading from, or null for the latest.</param>
+    /// <param name="createStream">If true, creates the stream if it does not already exist.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>True if the group was created.</returns>
+    Task<bool> StreamCreateConsumerGroupAsync(string key, string groupName, RedisValue? position = null, bool createStream = true, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Sets the last delivered ID of a consumer group.
+    /// </summary>
+    /// <param name="key">The key of the stream.</param>
+    /// <param name="groupName">The name of the consumer group.</param>
+    /// <param name="position">The new position to set.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>True if the position was set.</returns>
+    Task<bool> StreamConsumerGroupSetPositionAsync(string key, string groupName, RedisValue position, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Deletes a consumer group.
+    /// </summary>
+    /// <param name="key">The key of the stream.</param>
+    /// <param name="groupName">The name of the consumer group to delete.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>True if the group was deleted.</returns>
+    Task<bool> StreamDeleteConsumerGroupAsync(string key, string groupName, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Removes a consumer from a consumer group.
+    /// </summary>
+    /// <param name="key">The key of the stream.</param>
+    /// <param name="groupName">The name of the consumer group.</param>
+    /// <param name="consumerName">The name of the consumer to remove.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The number of pending entries that the consumer had before being removed.</returns>
+    Task<long> StreamDeleteConsumerAsync(string key, string groupName, string consumerName, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Reads entries from a stream as a member of a consumer group.
+    /// </summary>
+    /// <param name="key">The key of the stream.</param>
+    /// <param name="groupName">The name of the consumer group.</param>
+    /// <param name="consumerName">The name of the consumer.</param>
+    /// <param name="position">The position to read from, or null for new messages only (&gt;).</param>
+    /// <param name="count">The maximum number of entries to return, or null for all.</param>
+    /// <param name="noAck">If true, the messages are not added to the PEL (pending entry list).</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The stream entries read.</returns>
+    Task<StreamEntry[]> StreamReadGroupAsync(string key, string groupName, string consumerName, RedisValue? position = null, int? count = null, bool noAck = false, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Acknowledges one message as processed by a consumer group.
+    /// </summary>
+    /// <param name="key">The key of the stream.</param>
+    /// <param name="groupName">The name of the consumer group.</param>
+    /// <param name="messageId">The ID of the message to acknowledge.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The number of messages acknowledged (0 or 1).</returns>
+    Task<long> StreamAcknowledgeAsync(string key, string groupName, string messageId, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Acknowledges multiple messages as processed by a consumer group.
+    /// </summary>
+    /// <param name="key">The key of the stream.</param>
+    /// <param name="groupName">The name of the consumer group.</param>
+    /// <param name="messageIds">The IDs of the messages to acknowledge.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The number of messages acknowledged.</returns>
+    Task<long> StreamAcknowledgeAsync(string key, string groupName, string[] messageIds, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns a summary of pending messages for a consumer group.
+    /// </summary>
+    /// <param name="key">The key of the stream.</param>
+    /// <param name="groupName">The name of the consumer group.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>Summary information about pending messages.</returns>
+    Task<StreamPendingInfo> StreamPendingAsync(string key, string groupName, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns detailed information about pending messages for a consumer group.
+    /// </summary>
+    /// <param name="key">The key of the stream.</param>
+    /// <param name="groupName">The name of the consumer group.</param>
+    /// <param name="count">The maximum number of pending messages to return.</param>
+    /// <param name="consumerName">The consumer to filter by.</param>
+    /// <param name="minId">The minimum message ID, or null for the beginning.</param>
+    /// <param name="maxId">The maximum message ID, or null for the end.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>Detailed information about each pending message.</returns>
+    Task<StreamPendingMessageInfo[]> StreamPendingMessagesAsync(string key, string groupName, int count, RedisValue consumerName, RedisValue? minId = null, RedisValue? maxId = null, CommandFlags flag = CommandFlags.None);
+}

--- a/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
@@ -140,7 +140,7 @@ public class RedisConfiguration
     }
 
     /// <summary>
-    /// Gets or sets the time in seconds at which to send a heartbeat. A value of -1 means use the default from StackExchange.Redis.
+    /// Gets or sets the time in seconds at which to send a heartbeat. A value of -1 (default) means use the StackExchange.Redis default; 0 disables keepalive.
     /// </summary>
     public int? KeepAlive
     {
@@ -486,7 +486,7 @@ public class RedisConfiguration
                     if (ClientName != null)
                         newOptions.ClientName = ClientName;
 
-                    if (KeepAlive is > 0)
+                    if (KeepAlive is >= 0)
                         newOptions.KeepAlive = KeepAlive.Value;
 
                     if (IsSentinelCluster)

--- a/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Net.Security;
 using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 
 using Microsoft.Extensions.Logging;
 
@@ -25,7 +26,7 @@ public class RedisConfiguration
     private bool allowAdmin;
     private bool ssl;
     private int connectTimeout = 5000;
-    private int syncTimeout = 1000;
+    private int syncTimeout = 5000;
     private bool abortOnConnectFail;
     private int database;
     private RedisHost[] hosts = [];
@@ -36,6 +37,8 @@ public class RedisConfiguration
     private string? configurationChannel;
     private string? connectionString;
     private string? serviceName;
+    private string? clientName;
+    private int? keepAlive = -1;
     private int? connectRetry;
     private SslProtocols? sslProtocols;
     private Func<ProfilingSession>? profilingSessionProvider;
@@ -49,6 +52,12 @@ public class RedisConfiguration
     /// that this cannot be specified in the configuration-string.
     /// </summary>
     public event RemoteCertificateValidationCallback? CertificateValidation;
+
+    /// <summary>
+    /// A LocalCertificateSelectionCallback delegate responsible for selecting the certificate used for authentication; note
+    /// that this cannot be specified in the configuration-string.
+    /// </summary>
+    public event LocalCertificateSelectionCallback? CertificateSelection;
 
     /// <summary>
     /// Indicate if the current configuration is the default;
@@ -112,6 +121,34 @@ public class RedisConfiguration
         set
         {
             serviceName = value;
+            ResetConfigurationOptions();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the client name to use for all connections.
+    /// </summary>
+    public string? ClientName
+    {
+        get => clientName;
+
+        set
+        {
+            clientName = value;
+            ResetConfigurationOptions();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the time in seconds at which to send a heartbeat. A value of -1 means use the default from StackExchange.Redis.
+    /// </summary>
+    public int? KeepAlive
+    {
+        get => keepAlive;
+
+        set
+        {
+            keepAlive = value;
             ResetConfigurationOptions();
         }
     }
@@ -446,6 +483,12 @@ public class RedisConfiguration
                     if (ConnectRetry != null)
                         newOptions.ConnectRetry = ConnectRetry.Value;
 
+                    if (ClientName != null)
+                        newOptions.ClientName = ClientName;
+
+                    if (KeepAlive is > 0)
+                        newOptions.KeepAlive = KeepAlive.Value;
+
                     if (IsSentinelCluster)
                     {
                         newOptions.ServiceName = ServiceName;
@@ -470,6 +513,7 @@ public class RedisConfiguration
                     newOptions.SocketManager = new(GetType().Name, WorkCount, SocketManagerOptions);
 
                 newOptions.CertificateValidation += CertificateValidation;
+                newOptions.CertificateSelection += CertificateSelection;
                 options = newOptions;
             }
 

--- a/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Configuration/RedisConfiguration.cs
@@ -490,10 +490,7 @@ public class RedisConfiguration
                         newOptions.KeepAlive = KeepAlive.Value;
 
                     if (IsSentinelCluster)
-                    {
                         newOptions.ServiceName = ServiceName;
-                        newOptions.CommandMap = CommandMap.Sentinel;
-                    }
 
                     foreach (var redisHost in Hosts)
                         newOptions.EndPoints.Add(redisHost.Host, redisHost.Port);

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.Geo.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.Geo.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+using StackExchange.Redis.Extensions.Core.Helpers;
+
+namespace StackExchange.Redis.Extensions.Core.Implementations;
+
+/// <inheritdoc/>
+public partial class RedisDatabase
+{
+    /// <inheritdoc/>
+    public Task<bool> GeoAddAsync(string key, double longitude, double latitude, string member, CommandFlags flag = CommandFlags.None) =>
+        Database.GeoAddAsync(key, longitude, latitude, member, flag);
+
+    /// <inheritdoc/>
+    public Task<bool> GeoAddAsync(string key, GeoEntry value, CommandFlags flag = CommandFlags.None) =>
+        Database.GeoAddAsync(key, value, flag);
+
+    /// <inheritdoc/>
+    public Task<long> GeoAddAsync(string key, GeoEntry[] values, CommandFlags flag = CommandFlags.None) =>
+        Database.GeoAddAsync(key, values, flag);
+
+    /// <inheritdoc/>
+    public Task<bool> GeoRemoveAsync(string key, string member, CommandFlags flag = CommandFlags.None) =>
+        Database.GeoRemoveAsync(key, member, flag);
+
+    /// <inheritdoc/>
+    public Task<double?> GeoDistanceAsync(string key, string member1, string member2, GeoUnit unit = GeoUnit.Meters, CommandFlags flag = CommandFlags.None) =>
+        Database.GeoDistanceAsync(key, member1, member2, unit, flag);
+
+    /// <inheritdoc/>
+    public Task<string?> GeoHashAsync(string key, string member, CommandFlags flag = CommandFlags.None) =>
+        Database.GeoHashAsync(key, member, flag);
+
+    /// <inheritdoc/>
+    public Task<string?[]> GeoHashAsync(string key, string[] members, CommandFlags flag = CommandFlags.None) =>
+        Database.GeoHashAsync(key, members.ToFastArray(m => (RedisValue)m), flag);
+
+    /// <inheritdoc/>
+    public Task<GeoPosition?> GeoPositionAsync(string key, string member, CommandFlags flag = CommandFlags.None) =>
+        Database.GeoPositionAsync(key, member, flag);
+
+    /// <inheritdoc/>
+    public Task<GeoPosition?[]> GeoPositionAsync(string key, string[] members, CommandFlags flag = CommandFlags.None) =>
+        Database.GeoPositionAsync(key, members.ToFastArray(m => (RedisValue)m), flag);
+
+    /// <inheritdoc/>
+    public Task<GeoRadiusResult[]> GeoRadiusAsync(string key, string member, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flag = CommandFlags.None) =>
+        Database.GeoRadiusAsync(key, member, radius, unit, count, order, options, flag);
+
+    /// <inheritdoc/>
+    public Task<GeoRadiusResult[]> GeoRadiusAsync(string key, double longitude, double latitude, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flag = CommandFlags.None) =>
+        Database.GeoRadiusAsync(key, longitude, latitude, radius, unit, count, order, options, flag);
+
+    /// <inheritdoc/>
+    public Task<GeoRadiusResult[]> GeoSearchAsync(string key, string member, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flag = CommandFlags.None) =>
+        Database.GeoSearchAsync(key, member, shape, count, demandClosest, order, options, flag);
+
+    /// <inheritdoc/>
+    public Task<GeoRadiusResult[]> GeoSearchAsync(string key, double longitude, double latitude, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flag = CommandFlags.None) =>
+        Database.GeoSearchAsync(key, longitude, latitude, shape, count, demandClosest, order, options, flag);
+
+    /// <inheritdoc/>
+    public Task<long> GeoSearchAndStoreAsync(string sourceKey, string destinationKey, string member, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, bool storeDistances = false, CommandFlags flag = CommandFlags.None) =>
+        Database.GeoSearchAndStoreAsync(sourceKey, destinationKey, member, shape, count, demandClosest, order, storeDistances, flag);
+
+    /// <inheritdoc/>
+    public Task<long> GeoSearchAndStoreAsync(string sourceKey, string destinationKey, double longitude, double latitude, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, bool storeDistances = false, CommandFlags flag = CommandFlags.None) =>
+        Database.GeoSearchAndStoreAsync(sourceKey, destinationKey, longitude, latitude, shape, count, demandClosest, order, storeDistances, flag);
+}

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.Streams.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.Streams.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+using StackExchange.Redis.Extensions.Core.Helpers;
+
+namespace StackExchange.Redis.Extensions.Core.Implementations;
+
+/// <inheritdoc/>
+public partial class RedisDatabase
+{
+    /// <inheritdoc/>
+    public Task<RedisValue> StreamAddAsync<T>(string key, string fieldName, T value, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flag = CommandFlags.None)
+    {
+        var serializedValue = Serializer.Serialize(value);
+
+        return Database.StreamAddAsync(key, fieldName, serializedValue, messageId, maxLength, useApproximateMaxLength, flag);
+    }
+
+    /// <inheritdoc/>
+    public Task<RedisValue> StreamAddAsync(string key, NameValueEntry[] entries, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flag = CommandFlags.None) =>
+        Database.StreamAddAsync(key, entries, messageId, maxLength, useApproximateMaxLength, flag);
+
+    /// <inheritdoc/>
+    public Task<long> StreamLengthAsync(string key, CommandFlags flag = CommandFlags.None) =>
+        Database.StreamLengthAsync(key, flag);
+
+    /// <inheritdoc/>
+    public Task<long> StreamTrimAsync(string key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flag = CommandFlags.None) =>
+        Database.StreamTrimAsync(key, maxLength, useApproximateMaxLength, flag);
+
+    /// <inheritdoc/>
+    public Task<long> StreamDeleteAsync(string key, string[] messageIds, CommandFlags flag = CommandFlags.None) =>
+        Database.StreamDeleteAsync(key, messageIds.ToFastArray(id => (RedisValue)id), flag);
+
+    /// <inheritdoc/>
+    public Task<StreamEntry[]> StreamRangeAsync(string key, RedisValue? minId = null, RedisValue? maxId = null, int? count = null, Order messageOrder = Order.Ascending, CommandFlags flag = CommandFlags.None) =>
+        Database.StreamRangeAsync(key, minId, maxId, count, messageOrder, flag);
+
+    /// <inheritdoc/>
+    public Task<StreamEntry[]> StreamReadAsync(string key, RedisValue position, int? count = null, CommandFlags flag = CommandFlags.None) =>
+        Database.StreamReadAsync(key, position, count, flag);
+
+    /// <inheritdoc/>
+    public Task<bool> StreamCreateConsumerGroupAsync(string key, string groupName, RedisValue? position = null, bool createStream = true, CommandFlags flag = CommandFlags.None) =>
+        Database.StreamCreateConsumerGroupAsync(key, groupName, position, createStream, flag);
+
+    /// <inheritdoc/>
+    public Task<bool> StreamConsumerGroupSetPositionAsync(string key, string groupName, RedisValue position, CommandFlags flag = CommandFlags.None) =>
+        Database.StreamConsumerGroupSetPositionAsync(key, groupName, position, flag);
+
+    /// <inheritdoc/>
+    public Task<bool> StreamDeleteConsumerGroupAsync(string key, string groupName, CommandFlags flag = CommandFlags.None) =>
+        Database.StreamDeleteConsumerGroupAsync(key, groupName, flag);
+
+    /// <inheritdoc/>
+    public Task<long> StreamDeleteConsumerAsync(string key, string groupName, string consumerName, CommandFlags flag = CommandFlags.None) =>
+        Database.StreamDeleteConsumerAsync(key, groupName, consumerName, flag);
+
+    /// <inheritdoc/>
+    public Task<StreamEntry[]> StreamReadGroupAsync(string key, string groupName, string consumerName, RedisValue? position = null, int? count = null, bool noAck = false, CommandFlags flag = CommandFlags.None) =>
+        Database.StreamReadGroupAsync(key, groupName, consumerName, position, count, noAck, flag);
+
+    /// <inheritdoc/>
+    public Task<long> StreamAcknowledgeAsync(string key, string groupName, string messageId, CommandFlags flag = CommandFlags.None) =>
+        Database.StreamAcknowledgeAsync(key, groupName, messageId, flag);
+
+    /// <inheritdoc/>
+    public Task<long> StreamAcknowledgeAsync(string key, string groupName, string[] messageIds, CommandFlags flag = CommandFlags.None) =>
+        Database.StreamAcknowledgeAsync(key, groupName, messageIds.ToFastArray(id => (RedisValue)id), flag);
+
+    /// <inheritdoc/>
+    public Task<StreamPendingInfo> StreamPendingAsync(string key, string groupName, CommandFlags flag = CommandFlags.None) =>
+        Database.StreamPendingAsync(key, groupName, flag);
+
+    /// <inheritdoc/>
+    public Task<StreamPendingMessageInfo[]> StreamPendingMessagesAsync(string key, string groupName, int count, RedisValue consumerName, RedisValue? minId = null, RedisValue? maxId = null, CommandFlags flag = CommandFlags.None) =>
+        Database.StreamPendingMessagesAsync(key, groupName, count, consumerName, minId, maxId, flag);
+}

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
@@ -240,6 +240,10 @@ public partial class RedisDatabase : IRedisDatabase
             return false;
 
         var expiration = expiresAt.UtcDateTime.Subtract(DateTime.UtcNow);
+
+        if (expiration <= TimeSpan.Zero)
+            return false;
+
         var db = Database;
         var batch = db.CreateBatch();
 
@@ -249,7 +253,7 @@ public partial class RedisDatabase : IRedisDatabase
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
 
-        return tasks[0].Result;
+        return Array.TrueForAll(tasks, t => t.Result);
     }
 
     /// <inheritdoc/>
@@ -272,7 +276,7 @@ public partial class RedisDatabase : IRedisDatabase
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
 
-        return tasks[0].Result;
+        return Array.TrueForAll(tasks, t => t.Result);
     }
 
     /// <inheritdoc/>

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
@@ -236,9 +236,16 @@ public partial class RedisDatabase : IRedisDatabase
             .Select(x => new KeyValuePair<RedisKey, RedisValue>(x.Key, x.Value))
             .ToArray();
 
-        await Database.StringSetAsync(values, when, flag).ConfigureAwait(false);
+        if (values.Length == 0)
+            return false;
 
-        var tasks = values.ToFastArray(value => Database.KeyExpireAsync(value.Key, expiresAt.UtcDateTime, flag));
+        var expiration = expiresAt.UtcDateTime.Subtract(DateTime.UtcNow);
+        var db = Database;
+        var batch = db.CreateBatch();
+
+        var tasks = values.ToFastArray(v => batch.StringSetAsync(v.Key, v.Value, expiration, when, flag));
+
+        batch.Execute();
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
 
@@ -253,9 +260,15 @@ public partial class RedisDatabase : IRedisDatabase
             .Select(x => new KeyValuePair<RedisKey, RedisValue>(x.Key, x.Value))
             .ToArray();
 
-        await Database.StringSetAsync(values, when, flag).ConfigureAwait(false);
+        if (values.Length == 0)
+            return false;
 
-        var tasks = values.ToFastArray(value => Database.KeyExpireAsync(value.Key, expiresAt, flag));
+        var db = Database;
+        var batch = db.CreateBatch();
+
+        var tasks = values.ToFastArray(v => batch.StringSetAsync(v.Key, v.Value, expiresAt, when, flag));
+
+        batch.Execute();
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
 

--- a/src/core/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.csproj
+++ b/src/core/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.csproj
@@ -6,8 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="[2.8.*,3.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles" />
+    <PackageReference Include="StackExchange.Redis" Version="2.12.14" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
   </ItemGroup>
 </Project>

--- a/src/serializers/StackExchange.Redis.Extensions.MemoryPack/StackExchange.Redis.Extensions.MemoryPack.csproj
+++ b/src/serializers/StackExchange.Redis.Extensions.MemoryPack/StackExchange.Redis.Extensions.MemoryPack.csproj
@@ -6,9 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MemoryPack" Version="[1.21.3,2.0.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles" />
+    <PackageReference Include="MemoryPack" Version="[1.21.4,2.0.0)" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/serializers/StackExchange.Redis.Extensions.MsgPack/StackExchange.Redis.Extensions.MsgPack.csproj
+++ b/src/serializers/StackExchange.Redis.Extensions.MsgPack/StackExchange.Redis.Extensions.MsgPack.csproj
@@ -7,8 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="MsgPack.Cli" Version="[1.0.1,2.0.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/serializers/StackExchange.Redis.Extensions.Newtonsoft/StackExchange.Redis.Extensions.Newtonsoft.csproj
+++ b/src/serializers/StackExchange.Redis.Extensions.Newtonsoft/StackExchange.Redis.Extensions.Newtonsoft.csproj
@@ -6,9 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="[13.0.3,14.0.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles" />
+    <PackageReference Include="Newtonsoft.Json" Version="[13.0.4,14.0.0)" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/serializers/StackExchange.Redis.Extensions.Protobuf/StackExchange.Redis.Extensions.Protobuf.csproj
+++ b/src/serializers/StackExchange.Redis.Extensions.Protobuf/StackExchange.Redis.Extensions.Protobuf.csproj
@@ -6,9 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="protobuf-net" Version="[3.2.45,4.0.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles" />
+    <PackageReference Include="protobuf-net" Version="[3.2.56,4.0.0)" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/serializers/StackExchange.Redis.Extensions.ServiceStack/StackExchange.Redis.Extensions.ServiceStack.csproj
+++ b/src/serializers/StackExchange.Redis.Extensions.ServiceStack/StackExchange.Redis.Extensions.ServiceStack.csproj
@@ -6,9 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ServiceStack.Text" Version="[8.5.*,9.0.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles" />
+    <PackageReference Include="ServiceStack.Text" Version="[10.0.*,11.0.0)" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/serializers/StackExchange.Redis.Extensions.System.Text.Json/StackExchange.Redis.Extensions.System.Text.Json.csproj
+++ b/src/serializers/StackExchange.Redis.Extensions.System.Text.Json/StackExchange.Redis.Extensions.System.Text.Json.csproj
@@ -7,9 +7,7 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/serializers/StackExchange.Redis.Extensions.Utf8Json/StackExchange.Redis.Extensions.Utf8Json.csproj
+++ b/src/serializers/StackExchange.Redis.Extensions.Utf8Json/StackExchange.Redis.Extensions.Utf8Json.csproj
@@ -7,8 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Utf8Json" Version="[1.3.7,2.0.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/CacheClientTestBase.Geo.cs
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/CacheClientTestBase.Geo.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace StackExchange.Redis.Extensions.Core.Tests;
+
+public abstract partial class CacheClientTestBase
+{
+    [Fact]
+    public async Task GeoAdd_SingleMember_ShouldAddAndRetrievePosition_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        var added = await Sut.GetDefaultDatabase().GeoAddAsync(key, 13.361389, 38.115556, "Palermo");
+
+        Assert.True(added);
+
+        var position = await Sut.GetDefaultDatabase().GeoPositionAsync(key, "Palermo");
+
+        Assert.NotNull(position);
+        Assert.InRange(position.Value.Longitude, 13.36, 13.37);
+        Assert.InRange(position.Value.Latitude, 38.11, 38.12);
+    }
+
+    [Fact]
+    public async Task GeoAdd_MultipleMembers_ShouldAddAll_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        var entries = new[]
+        {
+            new GeoEntry(13.361389, 38.115556, "Palermo"),
+            new GeoEntry(15.087269, 37.502669, "Catania"),
+            new GeoEntry(12.496366, 41.902782, "Roma"),
+        };
+
+        var count = await Sut.GetDefaultDatabase().GeoAddAsync(key, entries);
+
+        Assert.Equal(3, count);
+    }
+
+    [Fact]
+    public async Task GeoRemove_ExistingMember_ShouldRemove_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        await Sut.GetDefaultDatabase().GeoAddAsync(key, 13.361389, 38.115556, "Palermo");
+
+        var removed = await Sut.GetDefaultDatabase().GeoRemoveAsync(key, "Palermo");
+
+        Assert.True(removed);
+
+        var position = await Sut.GetDefaultDatabase().GeoPositionAsync(key, "Palermo");
+
+        Assert.Null(position);
+    }
+
+    [Fact]
+    public async Task GeoDistance_BetweenTwoMembers_ShouldReturnCorrectDistance_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        await Sut.GetDefaultDatabase().GeoAddAsync(key, new[]
+        {
+            new GeoEntry(13.361389, 38.115556, "Palermo"),
+            new GeoEntry(15.087269, 37.502669, "Catania"),
+        });
+
+        var distance = await Sut.GetDefaultDatabase().GeoDistanceAsync(key, "Palermo", "Catania", GeoUnit.Kilometers);
+
+        Assert.NotNull(distance);
+        Assert.InRange(distance.Value, 160, 170);
+    }
+
+    [Fact]
+    public async Task GeoHash_SingleMember_ShouldReturnHash_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        await Sut.GetDefaultDatabase().GeoAddAsync(key, 13.361389, 38.115556, "Palermo");
+
+        var hash = await Sut.GetDefaultDatabase().GeoHashAsync(key, "Palermo");
+
+        Assert.NotNull(hash);
+        Assert.NotEmpty(hash);
+    }
+
+    [Fact]
+    public async Task GeoHash_MultipleMembers_ShouldReturnHashes_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        await Sut.GetDefaultDatabase().GeoAddAsync(key, new[]
+        {
+            new GeoEntry(13.361389, 38.115556, "Palermo"),
+            new GeoEntry(15.087269, 37.502669, "Catania"),
+        });
+
+        var hashes = await Sut.GetDefaultDatabase().GeoHashAsync(key, new[] { "Palermo", "Catania" });
+
+        Assert.Equal(2, hashes.Length);
+        Assert.All(hashes, h => Assert.NotNull(h));
+    }
+
+    [Fact]
+    public async Task GeoPosition_MultipleMembers_ShouldReturnPositions_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        await Sut.GetDefaultDatabase().GeoAddAsync(key, new[]
+        {
+            new GeoEntry(13.361389, 38.115556, "Palermo"),
+            new GeoEntry(15.087269, 37.502669, "Catania"),
+        });
+
+        var positions = await Sut.GetDefaultDatabase().GeoPositionAsync(key, new[] { "Palermo", "Catania" });
+
+        Assert.Equal(2, positions.Length);
+        Assert.All(positions, p => Assert.NotNull(p));
+    }
+
+    [Fact]
+    public async Task GeoRadius_ByCoordinates_ShouldReturnNearbyMembers_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        await Sut.GetDefaultDatabase().GeoAddAsync(key, new[]
+        {
+            new GeoEntry(13.361389, 38.115556, "Palermo"),
+            new GeoEntry(15.087269, 37.502669, "Catania"),
+            new GeoEntry(12.496366, 41.902782, "Roma"),
+        });
+
+        var results = await Sut.GetDefaultDatabase().GeoRadiusAsync(key, 13.361389, 38.115556, 200, GeoUnit.Kilometers);
+
+        Assert.NotEmpty(results);
+        Assert.Contains(results, r => r.Member == "Palermo");
+        Assert.Contains(results, r => r.Member == "Catania");
+        Assert.DoesNotContain(results, r => r.Member == "Roma");
+    }
+
+    [Fact]
+    public async Task GeoSearch_ByMember_WithCircle_ShouldReturnResults_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        await Sut.GetDefaultDatabase().GeoAddAsync(key, new[]
+        {
+            new GeoEntry(13.361389, 38.115556, "Palermo"),
+            new GeoEntry(15.087269, 37.502669, "Catania"),
+            new GeoEntry(12.496366, 41.902782, "Roma"),
+        });
+
+        var results = await Sut.GetDefaultDatabase().GeoSearchAsync(
+            key,
+            "Palermo",
+            new GeoSearchCircle(200, GeoUnit.Kilometers),
+            count: 10,
+            order: Order.Ascending);
+
+        Assert.NotEmpty(results);
+        Assert.Equal("Palermo", results[0].Member.ToString());
+    }
+}

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/CacheClientTestBase.Streams.cs
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/CacheClientTestBase.Streams.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace StackExchange.Redis.Extensions.Core.Tests;
+
+public abstract partial class CacheClientTestBase
+{
+    [Fact]
+    public async Task StreamAdd_Typed_ShouldAddAndRead_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        var messageId = await Sut.GetDefaultDatabase().StreamAddAsync(key, "payload", "test-value");
+
+        Assert.False(messageId.IsNull);
+
+        var entries = await Sut.GetDefaultDatabase().StreamRangeAsync(key);
+
+        Assert.Single(entries);
+        Assert.Equal(messageId, entries[0].Id);
+    }
+
+    [Fact]
+    public async Task StreamAdd_RawEntries_ShouldAddMultipleFields_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        var entries = new[]
+        {
+            new NameValueEntry("field1", "value1"),
+            new NameValueEntry("field2", "value2"),
+        };
+
+        var messageId = await Sut.GetDefaultDatabase().StreamAddAsync(key, entries);
+
+        Assert.False(messageId.IsNull);
+
+        var result = await Sut.GetDefaultDatabase().StreamRangeAsync(key);
+
+        Assert.Single(result);
+        Assert.Equal(2, result[0].Values.Length);
+    }
+
+    [Fact]
+    public async Task StreamLength_ShouldReturnCorrectCount_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        await Sut.GetDefaultDatabase().StreamAddAsync(key, "f", "v1");
+        await Sut.GetDefaultDatabase().StreamAddAsync(key, "f", "v2");
+        await Sut.GetDefaultDatabase().StreamAddAsync(key, "f", "v3");
+
+        var length = await Sut.GetDefaultDatabase().StreamLengthAsync(key);
+
+        Assert.Equal(3, length);
+    }
+
+    [Fact]
+    public async Task StreamTrim_ShouldReduceLength_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        for (var i = 0; i < 10; i++)
+            await Sut.GetDefaultDatabase().StreamAddAsync(key, "f", $"v{i}");
+
+        var trimmed = await Sut.GetDefaultDatabase().StreamTrimAsync(key, 5);
+
+        Assert.True(trimmed >= 5);
+
+        var length = await Sut.GetDefaultDatabase().StreamLengthAsync(key);
+
+        Assert.True(length <= 5);
+    }
+
+    [Fact]
+    public async Task StreamDelete_ShouldRemoveEntry_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        var id = await Sut.GetDefaultDatabase().StreamAddAsync(key, "f", "v");
+
+        var deleted = await Sut.GetDefaultDatabase().StreamDeleteAsync(key, new[] { id.ToString()! });
+
+        Assert.Equal(1, deleted);
+    }
+
+    [Fact]
+    public async Task StreamRead_ShouldReadFromPosition_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        await Sut.GetDefaultDatabase().StreamAddAsync(key, "f", "v1");
+        await Sut.GetDefaultDatabase().StreamAddAsync(key, "f", "v2");
+
+        var entries = await Sut.GetDefaultDatabase().StreamReadAsync(key, "0-0");
+
+        Assert.Equal(2, entries.Length);
+    }
+
+    [Fact]
+    public async Task StreamRange_Descending_ShouldReverseOrder_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+
+        var id1 = await Sut.GetDefaultDatabase().StreamAddAsync(key, "f", "v1");
+        var id2 = await Sut.GetDefaultDatabase().StreamAddAsync(key, "f", "v2");
+
+        var entries = await Sut.GetDefaultDatabase().StreamRangeAsync(key, messageOrder: Order.Descending);
+
+        Assert.Equal(2, entries.Length);
+        Assert.Equal(id2, entries[0].Id);
+        Assert.Equal(id1, entries[1].Id);
+    }
+
+    [Fact]
+    public async Task StreamConsumerGroup_FullWorkflow_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        const string group = "test-group";
+        const string consumer = "test-consumer";
+
+        // Add some messages first
+        await Sut.GetDefaultDatabase().StreamAddAsync(key, "f", "v1");
+        await Sut.GetDefaultDatabase().StreamAddAsync(key, "f", "v2");
+
+        // Create group from beginning
+        var created = await Sut.GetDefaultDatabase().StreamCreateConsumerGroupAsync(key, group, "0-0");
+
+        Assert.True(created);
+
+        // Read as consumer
+        var entries = await Sut.GetDefaultDatabase().StreamReadGroupAsync(key, group, consumer, ">", count: 10);
+
+        Assert.Equal(2, entries.Length);
+
+        // Acknowledge
+        var acked = await Sut.GetDefaultDatabase().StreamAcknowledgeAsync(key, group, entries[0].Id!);
+
+        Assert.Equal(1, acked);
+
+        // Check pending (1 should still be pending)
+        var pending = await Sut.GetDefaultDatabase().StreamPendingAsync(key, group);
+
+        Assert.Equal(1, pending.PendingMessageCount);
+
+        // Acknowledge the second one
+        await Sut.GetDefaultDatabase().StreamAcknowledgeAsync(key, group, new[] { entries[1].Id.ToString()! });
+
+        // Delete consumer
+        var pendingRemoved = await Sut.GetDefaultDatabase().StreamDeleteConsumerAsync(key, group, consumer);
+
+        Assert.Equal(0, pendingRemoved);
+
+        // Delete group
+        var deleted = await Sut.GetDefaultDatabase().StreamDeleteConsumerGroupAsync(key, group);
+
+        Assert.True(deleted);
+    }
+}

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/CacheClientTestBase.cs
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/CacheClientTestBase.cs
@@ -636,6 +636,86 @@ public abstract partial class CacheClientTestBase : IDisposable
     }
 
     [Fact]
+    public async Task AddAllAsync_WithExpiry_EmptyItems_ShouldReturnFalse_Async()
+    {
+        var emptyItems = Array.Empty<Tuple<string, string>>();
+
+        var resultTimeSpan = await Sut.GetDefaultDatabase().AddAllAsync(emptyItems, TimeSpan.FromMinutes(5));
+        var resultDateTimeOffset = await Sut.GetDefaultDatabase().AddAllAsync(emptyItems, DateTimeOffset.UtcNow.AddMinutes(5));
+
+        Assert.False(resultTimeSpan);
+        Assert.False(resultDateTimeOffset);
+    }
+
+    [Fact]
+    public async Task AddAllAsync_WithDateTimeOffsetExpiry_PastDate_ShouldReturnFalse_Async()
+    {
+        var items = new Tuple<string, string>[]
+        {
+            new(Guid.NewGuid().ToString(), "value1"),
+            new(Guid.NewGuid().ToString(), "value2"),
+        };
+
+        var result = await Sut.GetDefaultDatabase().AddAllAsync(items, DateTimeOffset.UtcNow.AddMinutes(-5));
+
+        Assert.False(result);
+
+        foreach (var item in items)
+        {
+            var exists = await Sut.GetDefaultDatabase().ExistsAsync(item.Item1);
+            Assert.False(exists);
+        }
+    }
+
+    [Fact]
+    public async Task AddAllAsync_WithDateTimeOffsetExpiry_ShouldSetTTL_Async()
+    {
+        var key1 = Guid.NewGuid().ToString();
+        var key2 = Guid.NewGuid().ToString();
+        var items = new Tuple<string, string>[]
+        {
+            new(key1, "value1"),
+            new(key2, "value2"),
+        };
+
+        var result = await Sut.GetDefaultDatabase().AddAllAsync(items, DateTimeOffset.UtcNow.AddMinutes(10));
+
+        Assert.True(result);
+
+        var ttl1 = await db.KeyTimeToLiveAsync(key1);
+        var ttl2 = await db.KeyTimeToLiveAsync(key2);
+
+        Assert.NotNull(ttl1);
+        Assert.NotNull(ttl2);
+        Assert.True(ttl1.Value.TotalSeconds > 0);
+        Assert.True(ttl2.Value.TotalSeconds > 0);
+    }
+
+    [Fact]
+    public async Task AddAllAsync_WithTimeSpanExpiry_ShouldSetTTL_Async()
+    {
+        var key1 = Guid.NewGuid().ToString();
+        var key2 = Guid.NewGuid().ToString();
+        var items = new Tuple<string, string>[]
+        {
+            new(key1, "value1"),
+            new(key2, "value2"),
+        };
+
+        var result = await Sut.GetDefaultDatabase().AddAllAsync(items, TimeSpan.FromMinutes(10));
+
+        Assert.True(result);
+
+        var ttl1 = await db.KeyTimeToLiveAsync(key1);
+        var ttl2 = await db.KeyTimeToLiveAsync(key2);
+
+        Assert.NotNull(ttl1);
+        Assert.NotNull(ttl2);
+        Assert.True(ttl1.Value.TotalSeconds > 0);
+        Assert.True(ttl2.Value.TotalSeconds > 0);
+    }
+
+    [Fact]
     public async Task Adding_Collection_To_Redis_Should_Work_Correctly_Async()
     {
         var items = Range(1, 3).Select(i => new TestClass<string> { Key = $"key{i.ToString(CultureInfo.InvariantCulture)}", Value = $"value{i.ToString(CultureInfo.InvariantCulture)}" }).ToArray();

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/StackExchange.Redis.Extensions.Core.Tests.csproj
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/StackExchange.Redis.Extensions.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -35,7 +35,7 @@
     <ProjectReference Include="..\..\src\serializers\StackExchange.Redis.Extensions.Utf8Json\StackExchange.Redis.Extensions.Utf8Json.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0' ">
     <ProjectReference Include="..\..\src\serializers\StackExchange.Redis.Extensions.MemoryPack\StackExchange.Redis.Extensions.MemoryPack.csproj" />
   </ItemGroup>
 

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/StackExchange.Redis.Extensions.Core.Tests.csproj
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/StackExchange.Redis.Extensions.Core.Tests.csproj
@@ -8,21 +8,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Neovolve.Logging.Xunit" Version="6.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.categories" Version="2.0.8" />
+    <PackageReference Include="xunit.categories" Version="3.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Adds two long-requested features to the library: **GeoSpatial indexes** and **Redis Streams**.

Closes #245
Closes #190

> **Note:** This branch is based on `feature/net10-support` (PR #620), which is based on `fix/quick-wins-cleanup` (PR #618). Merge order: #618 → #620 → this PR.

## GeoSpatial Support (#245)

New partial files: `IRedisDatabase.Geo.cs` + `RedisDatabase.Geo.cs`

**16 methods** covering the full Redis Geo command set:

| Method | Redis Command | Description |
|--------|--------------|-------------|
| `GeoAddAsync` (3 overloads) | GEOADD | Add members with coordinates |
| `GeoRemoveAsync` | ZREM (geo key) | Remove a member |
| `GeoDistanceAsync` | GEODIST | Distance between two members |
| `GeoHashAsync` (2 overloads) | GEOHASH | Get geohash strings |
| `GeoPositionAsync` (2 overloads) | GEOPOS | Get coordinates |
| `GeoRadiusAsync` (2 overloads) | GEORADIUS | Search by radius (legacy) |
| `GeoSearchAsync` (2 overloads) | GEOSEARCH | Search by shape (Redis 6.2+) |
| `GeoSearchAndStoreAsync` (2 overloads) | GEOSEARCHSTORE | Search and store results |

**Design decisions:**
- Geo members are `string` identifiers — no serialization needed (coordinates are stored internally by Redis as sorted set scores)
- SE.Redis value types (`GeoPosition`, `GeoRadiusResult`, `GeoEntry`, `GeoSearchShape`) are exposed directly — no wrapper models needed
- Follows the same `flag` parameter convention as all other partial interfaces

## Redis Streams Support (#190)

New partial files: `IRedisDatabase.Streams.cs` + `RedisDatabase.Streams.cs`

**16 methods** covering the core Streams workflow:

| Method | Redis Command | Description |
|--------|--------------|-------------|
| `StreamAddAsync<T>` | XADD | Add serialized entry (typed) |
| `StreamAddAsync` | XADD | Add raw multi-field entry |
| `StreamLengthAsync` | XLEN | Stream length |
| `StreamTrimAsync` | XTRIM | Trim stream |
| `StreamDeleteAsync` | XDEL | Delete entries |
| `StreamRangeAsync` | XRANGE/XREVRANGE | Range queries |
| `StreamReadAsync` | XREAD | Read from position |
| `StreamCreateConsumerGroupAsync` | XGROUP CREATE | Create consumer group |
| `StreamConsumerGroupSetPositionAsync` | XGROUP SETID | Set group position |
| `StreamDeleteConsumerGroupAsync` | XGROUP DESTROY | Delete group |
| `StreamDeleteConsumerAsync` | XGROUP DELCONSUMER | Remove consumer |
| `StreamReadGroupAsync` | XREADGROUP | Read as consumer |
| `StreamAcknowledgeAsync` (2 overloads) | XACK | Acknowledge messages |
| `StreamPendingAsync` | XPENDING | Pending summary |
| `StreamPendingMessagesAsync` | XPENDING (detail) | Pending details |

**Design decisions:**
- `StreamAddAsync<T>` serializes values via `ISerializer` into a single named field — consistent with how Hash operations work
- `StreamAddAsync(NameValueEntry[])` provides raw multi-field access for advanced use cases
- Read operations return raw `StreamEntry[]` — callers deserialize specific fields using `Serializer.Deserialize<T>()` on the `NameValueEntry.Value` they need
- Advanced operations (XCLAIM, XAUTOCLAIM, XINFO, multi-stream XREAD) are intentionally omitted — callers who need them can use `Database` directly
- `createStream = true` default on `StreamCreateConsumerGroupAsync` for convenience

## Test plan

- [ ] Verify GeoAdd + GeoPosition round-trip
- [ ] Verify GeoDistance returns correct units
- [ ] Verify GeoSearch with circle and box shapes
- [ ] Verify StreamAdd<T> serializes and StreamRange returns entries
- [ ] Verify consumer group workflow: create group → add messages → read group → acknowledge
- [ ] Verify StreamTrim and StreamDelete
- [ ] All existing tests pass without modification