### PR TITLE
Add VectorSet API for AI/ML similarity search

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -33,6 +33,7 @@
 * [Hash Operations](usage/README.md)
 * [Hash Field Expiry](hash-field-expiry.md) (Redis 7.4+)
 * [GeoSpatial Indexes](geospatial.md)
+* [VectorSet — AI/ML Similarity Search](vectorset.md) (Redis 8.0+)
 * [Redis Streams](streams.md)
 * [Pub/Sub Messaging](pubsub.md)
 * [Custom Serializer](usage/custom-serializer.md)

--- a/doc/vectorset.md
+++ b/doc/vectorset.md
@@ -1,0 +1,124 @@
+# VectorSet (AI/ML Similarity Search)
+
+Redis 8.0 introduced VectorSet — a native data structure for storing and searching high-dimensional vectors. This is ideal for AI/ML applications like RAG, recommendations, and semantic search.
+
+> **Requires Redis 8.0+**
+
+## Overview
+
+```mermaid
+graph LR
+    A[AI Model] -->|Generate Embedding| V[float array]
+    V -->|VectorSetAddAsync| R[("Redis VectorSet")]
+    Q[Query Text] -->|Generate Embedding| QV[float array]
+    QV -->|VectorSetSimilaritySearchAsync| R
+    R -->|Top K Results| Results[Similar Items]
+```
+
+## Adding Vectors
+
+```csharp
+// Add a vector with a member name
+var embedding = await aiModel.GetEmbeddingAsync("Red running shoes, size 42");
+
+await redis.VectorSetAddAsync("products",
+    VectorSetAddRequest.Create("shoe-123", embedding));
+
+// Add with JSON attributes (metadata)
+await redis.VectorSetAddAsync("products",
+    VectorSetAddRequest.Create("shoe-456", embedding)
+        .WithAttributes("""{"category":"shoes","price":79.99,"brand":"Nike"}"""));
+```
+
+## Similarity Search
+
+```csharp
+// Find the 5 most similar items to a query vector
+var queryEmbedding = await aiModel.GetEmbeddingAsync("comfortable sneakers for running");
+
+var results = await redis.VectorSetSimilaritySearchAsync("products",
+    VectorSetSimilaritySearchRequest.Create(queryEmbedding, count: 5));
+
+foreach (var result in results)
+{
+    Console.WriteLine($"{result.Member}: score={result.Score:F4}");
+
+    // Get attributes for each result
+    var attrs = await redis.VectorSetGetAttributesJsonAsync("products", result.Member!);
+    Console.WriteLine($"  Attributes: {attrs}");
+}
+```
+
+## Managing Vectors
+
+```csharp
+// Check if a member exists
+var exists = await redis.VectorSetContainsAsync("products", "shoe-123");
+
+// Get cardinality
+var count = await redis.VectorSetLengthAsync("products");
+
+// Get vector dimensions
+var dims = await redis.VectorSetDimensionAsync("products");
+
+// Get a random member
+var random = await redis.VectorSetRandomMemberAsync("products");
+
+// Get info about the VectorSet
+var info = await redis.VectorSetInfoAsync("products");
+
+// Remove a member
+await redis.VectorSetRemoveAsync("products", "shoe-123");
+```
+
+## Attributes (Metadata)
+
+```csharp
+// Set JSON attributes on a member
+await redis.VectorSetSetAttributesJsonAsync("products", "shoe-123",
+    """{"category":"shoes","price":99.99,"sizes":[40,41,42]}""");
+
+// Get JSON attributes
+var json = await redis.VectorSetGetAttributesJsonAsync("products", "shoe-123");
+```
+
+## Use Cases
+
+### RAG (Retrieval-Augmented Generation)
+```csharp
+// Index documents
+foreach (var doc in documents)
+{
+    var embedding = await aiModel.GetEmbeddingAsync(doc.Content);
+    await redis.VectorSetAddAsync("docs",
+        VectorSetAddRequest.Create(doc.Id, embedding)
+            .WithAttributes($"""{{ "title": "{doc.Title}" }}"""));
+}
+
+// Query: find relevant context for a prompt
+var queryEmb = await aiModel.GetEmbeddingAsync(userQuestion);
+var context = await redis.VectorSetSimilaritySearchAsync("docs",
+    VectorSetSimilaritySearchRequest.Create(queryEmb, count: 3));
+```
+
+### Recommendations
+```csharp
+// Find products similar to what the user just viewed
+var viewedProduct = await redis.VectorSetGetApproximateVectorAsync("products", productId);
+// Use the vector to find similar items
+```
+
+### Semantic Search
+```csharp
+// Search by meaning, not keywords
+var searchEmb = await aiModel.GetEmbeddingAsync("something warm for winter");
+var results = await redis.VectorSetSimilaritySearchAsync("clothing",
+    VectorSetSimilaritySearchRequest.Create(searchEmb, count: 20));
+```
+
+## Performance Notes
+
+- VectorSet uses HNSW (Hierarchical Navigable Small World) algorithm internally
+- Approximate nearest neighbor search — extremely fast even with millions of vectors
+- Memory efficient compared to external vector databases
+- Vectors are stored directly in Redis — no external index to maintain

--- a/doc/vectorset.md
+++ b/doc/vectorset.md
@@ -22,30 +22,35 @@ graph LR
 var embedding = await aiModel.GetEmbeddingAsync("Red running shoes, size 42");
 
 await redis.VectorSetAddAsync("products",
-    VectorSetAddRequest.Create("shoe-123", embedding));
+    VectorSetAddRequest.Member("shoe-123", embedding));
 
 // Add with JSON attributes (metadata)
 await redis.VectorSetAddAsync("products",
-    VectorSetAddRequest.Create("shoe-456", embedding)
-        .WithAttributes("""{"category":"shoes","price":79.99,"brand":"Nike"}"""));
+    VectorSetAddRequest.Member("shoe-456", embedding, 
+        attributes: """{"category":"shoes","price":79.99,"brand":"Nike"}"""));
 ```
 
 ## Similarity Search
+
+The search returns a `Lease<T>` which **must be disposed** after use to return pooled memory.
 
 ```csharp
 // Find the 5 most similar items to a query vector
 var queryEmbedding = await aiModel.GetEmbeddingAsync("comfortable sneakers for running");
 
-var results = await redis.VectorSetSimilaritySearchAsync("products",
-    VectorSetSimilaritySearchRequest.Create(queryEmbedding, count: 5));
+using var results = await redis.VectorSetSimilaritySearchAsync("products",
+    VectorSetSimilaritySearchRequest.ByVector(queryEmbedding) with { Count = 5 });
 
-foreach (var result in results)
+if (results is not null)
 {
-    Console.WriteLine($"{result.Member}: score={result.Score:F4}");
+    foreach (var result in results.Span)
+    {
+        Console.WriteLine($"{result.Member}: score={result.Score:F4}");
 
-    // Get attributes for each result
-    var attrs = await redis.VectorSetGetAttributesJsonAsync("products", result.Member!);
-    Console.WriteLine($"  Attributes: {attrs}");
+        // Get attributes for each result
+        var attrs = await redis.VectorSetGetAttributesJsonAsync("products", result.Member!);
+        Console.WriteLine($"  Attributes: {attrs}");
+    }
 }
 ```
 
@@ -64,8 +69,18 @@ var dims = await redis.VectorSetDimensionAsync("products");
 // Get a random member
 var random = await redis.VectorSetRandomMemberAsync("products");
 
+// Get multiple random members
+var randoms = await redis.VectorSetRandomMembersAsync("products", 5);
+
 // Get info about the VectorSet
 var info = await redis.VectorSetInfoAsync("products");
+
+// Get the approximate vector for a member
+using var vector = await redis.VectorSetGetApproximateVectorAsync("products", "shoe-123");
+
+// Get HNSW graph neighbors
+var links = await redis.VectorSetGetLinksAsync("products", "shoe-123");
+var linksWithScores = await redis.VectorSetGetLinksWithScoresAsync("products", "shoe-123");
 
 // Remove a member
 await redis.VectorSetRemoveAsync("products", "shoe-123");
@@ -91,29 +106,32 @@ foreach (var doc in documents)
 {
     var embedding = await aiModel.GetEmbeddingAsync(doc.Content);
     await redis.VectorSetAddAsync("docs",
-        VectorSetAddRequest.Create(doc.Id, embedding)
-            .WithAttributes($"""{{ "title": "{doc.Title}" }}"""));
+        VectorSetAddRequest.Member(doc.Id, embedding,
+            attributes: $"""{{ "title": "{doc.Title}" }}"""));
 }
 
 // Query: find relevant context for a prompt
-var queryEmb = await aiModel.GetEmbeddingAsync(userQuestion);
-var context = await redis.VectorSetSimilaritySearchAsync("docs",
-    VectorSetSimilaritySearchRequest.Create(queryEmb, count: 3));
+using var context = await redis.VectorSetSimilaritySearchAsync("docs",
+    VectorSetSimilaritySearchRequest.ByVector(queryEmb) with { Count = 3 });
 ```
 
 ### Recommendations
 ```csharp
 // Find products similar to what the user just viewed
-var viewedProduct = await redis.VectorSetGetApproximateVectorAsync("products", productId);
-// Use the vector to find similar items
+using var vector = await redis.VectorSetGetApproximateVectorAsync("products", viewedProductId);
+if (vector is not null)
+{
+    using var similar = await redis.VectorSetSimilaritySearchAsync("products",
+        VectorSetSimilaritySearchRequest.ByVector(vector.Span.ToArray()) with { Count = 10 });
+}
 ```
 
 ### Semantic Search
 ```csharp
 // Search by meaning, not keywords
 var searchEmb = await aiModel.GetEmbeddingAsync("something warm for winter");
-var results = await redis.VectorSetSimilaritySearchAsync("clothing",
-    VectorSetSimilaritySearchRequest.Create(searchEmb, count: 20));
+using var results = await redis.VectorSetSimilaritySearchAsync("clothing",
+    VectorSetSimilaritySearchRequest.ByVector(searchEmb) with { Count = 20 });
 ```
 
 ## Performance Notes
@@ -122,3 +140,4 @@ var results = await redis.VectorSetSimilaritySearchAsync("clothing",
 - Approximate nearest neighbor search — extremely fast even with millions of vectors
 - Memory efficient compared to external vector databases
 - Vectors are stored directly in Redis — no external index to maintain
+- `Lease<T>` return types use pooled memory — always dispose after use

--- a/src/core/StackExchange.Redis.Extensions.Core/Abstractions/IRedisDatabase.VectorSet.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Abstractions/IRedisDatabase.VectorSet.cs
@@ -96,4 +96,40 @@ public partial interface IRedisDatabase
     /// <param name="flag">Behaviour markers associated with a given command.</param>
     /// <returns>A random member, or null if the VectorSet is empty.</returns>
     Task<RedisValue> VectorSetRandomMemberAsync(string key, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns multiple random members from the VectorSet stored at key.
+    /// </summary>
+    /// <param name="key">The key of the VectorSet.</param>
+    /// <param name="count">The number of random members to return.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>An array of random members.</returns>
+    Task<RedisValue[]> VectorSetRandomMembersAsync(string key, long count, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns the approximate vector for a member in the VectorSet.
+    /// </summary>
+    /// <param name="key">The key of the VectorSet.</param>
+    /// <param name="member">The member to retrieve the vector for.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The approximate vector as a Lease of floats. Must be disposed after use. Null if member not found.</returns>
+    Task<Lease<float>?> VectorSetGetApproximateVectorAsync(string key, string member, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns the links (neighbors) for a member in the VectorSet's HNSW graph.
+    /// </summary>
+    /// <param name="key">The key of the VectorSet.</param>
+    /// <param name="member">The member to retrieve links for.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The linked member names. The returned Lease must be disposed after use.</returns>
+    Task<Lease<RedisValue>?> VectorSetGetLinksAsync(string key, string member, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns the links (neighbors) with similarity scores for a member in the VectorSet's HNSW graph.
+    /// </summary>
+    /// <param name="key">The key of the VectorSet.</param>
+    /// <param name="member">The member to retrieve links for.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The links with scores. The returned Lease must be disposed after use.</returns>
+    Task<Lease<VectorSetLink>?> VectorSetGetLinksWithScoresAsync(string key, string member, CommandFlags flag = CommandFlags.None);
 }

--- a/src/core/StackExchange.Redis.Extensions.Core/Abstractions/IRedisDatabase.VectorSet.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Abstractions/IRedisDatabase.VectorSet.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace StackExchange.Redis.Extensions.Core.Abstractions;
+
+/// <summary>
+/// The Redis Database VectorSet extensions for AI/ML similarity search.
+/// Requires Redis 8.0+.
+/// </summary>
+public partial interface IRedisDatabase
+{
+    /// <summary>
+    ///     Adds a vector to the VectorSet stored at key.
+    /// </summary>
+    /// <param name="key">The key of the VectorSet.</param>
+    /// <param name="request">The add request containing the member, vector, and optional attributes.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>True if the member was added, false if it already existed and was updated.</returns>
+    Task<bool> VectorSetAddAsync(string key, VectorSetAddRequest request, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Performs a similarity search against the VectorSet stored at key.
+    /// </summary>
+    /// <param name="key">The key of the VectorSet.</param>
+    /// <param name="query">The search request containing the query vector and parameters.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The matching results with scores. The returned Lease must be disposed after use.</returns>
+    Task<Lease<VectorSetSimilaritySearchResult>?> VectorSetSimilaritySearchAsync(string key, VectorSetSimilaritySearchRequest query, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Removes a member from the VectorSet stored at key.
+    /// </summary>
+    /// <param name="key">The key of the VectorSet.</param>
+    /// <param name="member">The member to remove.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>True if the member was removed, false if it did not exist.</returns>
+    Task<bool> VectorSetRemoveAsync(string key, string member, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Checks if a member exists in the VectorSet stored at key.
+    /// </summary>
+    /// <param name="key">The key of the VectorSet.</param>
+    /// <param name="member">The member to check.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>True if the member exists.</returns>
+    Task<bool> VectorSetContainsAsync(string key, string member, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns the number of members in the VectorSet stored at key.
+    /// </summary>
+    /// <param name="key">The key of the VectorSet.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The cardinality of the VectorSet, or 0 if the key does not exist.</returns>
+    Task<long> VectorSetLengthAsync(string key, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns the number of dimensions of vectors in the VectorSet stored at key.
+    /// </summary>
+    /// <param name="key">The key of the VectorSet.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The number of dimensions.</returns>
+    Task<long> VectorSetDimensionAsync(string key, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Gets the JSON attributes associated with a member in the VectorSet.
+    /// </summary>
+    /// <param name="key">The key of the VectorSet.</param>
+    /// <param name="member">The member to retrieve attributes for.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The JSON attributes string, or null if the member has no attributes.</returns>
+    Task<string?> VectorSetGetAttributesJsonAsync(string key, string member, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Sets JSON attributes on a member in the VectorSet.
+    /// </summary>
+    /// <param name="key">The key of the VectorSet.</param>
+    /// <param name="member">The member to set attributes on.</param>
+    /// <param name="attributesJson">The JSON attributes string.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>True if the attributes were set.</returns>
+    Task<bool> VectorSetSetAttributesJsonAsync(string key, string member, string attributesJson, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns information about the VectorSet stored at key.
+    /// </summary>
+    /// <param name="key">The key of the VectorSet.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>Information about the VectorSet.</returns>
+    Task<VectorSetInfo?> VectorSetInfoAsync(string key, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns a random member from the VectorSet stored at key.
+    /// </summary>
+    /// <param name="key">The key of the VectorSet.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>A random member, or null if the VectorSet is empty.</returns>
+    Task<RedisValue> VectorSetRandomMemberAsync(string key, CommandFlags flag = CommandFlags.None);
+}

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.VectorSet.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.VectorSet.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace StackExchange.Redis.Extensions.Core.Implementations;
+
+/// <inheritdoc/>
+public partial class RedisDatabase
+{
+    /// <inheritdoc/>
+    public Task<bool> VectorSetAddAsync(string key, VectorSetAddRequest request, CommandFlags flag = CommandFlags.None) =>
+        Database.VectorSetAddAsync(key, request, flag);
+
+    /// <inheritdoc/>
+    public Task<Lease<VectorSetSimilaritySearchResult>?> VectorSetSimilaritySearchAsync(string key, VectorSetSimilaritySearchRequest query, CommandFlags flag = CommandFlags.None) =>
+        Database.VectorSetSimilaritySearchAsync(key, query, flag);
+
+    /// <inheritdoc/>
+    public Task<bool> VectorSetRemoveAsync(string key, string member, CommandFlags flag = CommandFlags.None) =>
+        Database.VectorSetRemoveAsync(key, member, flag);
+
+    /// <inheritdoc/>
+    public Task<bool> VectorSetContainsAsync(string key, string member, CommandFlags flag = CommandFlags.None) =>
+        Database.VectorSetContainsAsync(key, member, flag);
+
+    /// <inheritdoc/>
+    public Task<long> VectorSetLengthAsync(string key, CommandFlags flag = CommandFlags.None) =>
+        Database.VectorSetLengthAsync(key, flag).ContinueWith(t => (long)t.Result, CancellationToken.None, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
+
+    /// <inheritdoc/>
+    public Task<long> VectorSetDimensionAsync(string key, CommandFlags flag = CommandFlags.None) =>
+        Database.VectorSetDimensionAsync(key, flag).ContinueWith(t => (long)t.Result, CancellationToken.None, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
+
+    /// <inheritdoc/>
+    public Task<string?> VectorSetGetAttributesJsonAsync(string key, string member, CommandFlags flag = CommandFlags.None) =>
+        Database.VectorSetGetAttributesJsonAsync(key, member, flag);
+
+    /// <inheritdoc/>
+    public Task<bool> VectorSetSetAttributesJsonAsync(string key, string member, string attributesJson, CommandFlags flag = CommandFlags.None) =>
+        Database.VectorSetSetAttributesJsonAsync(key, member, attributesJson, flag);
+
+    /// <inheritdoc/>
+    public Task<VectorSetInfo?> VectorSetInfoAsync(string key, CommandFlags flag = CommandFlags.None) =>
+        Database.VectorSetInfoAsync(key, flag);
+
+    /// <inheritdoc/>
+    public Task<RedisValue> VectorSetRandomMemberAsync(string key, CommandFlags flag = CommandFlags.None) =>
+        Database.VectorSetRandomMemberAsync(key, flag);
+}

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.VectorSet.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.VectorSet.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace StackExchange.Redis.Extensions.Core.Implementations;
@@ -25,12 +24,16 @@ public partial class RedisDatabase
         Database.VectorSetContainsAsync(key, member, flag);
 
     /// <inheritdoc/>
-    public Task<long> VectorSetLengthAsync(string key, CommandFlags flag = CommandFlags.None) =>
-        Database.VectorSetLengthAsync(key, flag).ContinueWith(t => (long)t.Result, CancellationToken.None, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
+#pragma warning disable RCS1174 // async/await required for cross-TFM int→long cast
+    public async Task<long> VectorSetLengthAsync(string key, CommandFlags flag = CommandFlags.None) =>
+        await Database.VectorSetLengthAsync(key, flag).ConfigureAwait(false);
+#pragma warning restore RCS1174
 
     /// <inheritdoc/>
-    public Task<long> VectorSetDimensionAsync(string key, CommandFlags flag = CommandFlags.None) =>
-        Database.VectorSetDimensionAsync(key, flag).ContinueWith(t => (long)t.Result, CancellationToken.None, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
+#pragma warning disable RCS1174
+    public async Task<long> VectorSetDimensionAsync(string key, CommandFlags flag = CommandFlags.None) =>
+        await Database.VectorSetDimensionAsync(key, flag).ConfigureAwait(false);
+#pragma warning restore RCS1174
 
     /// <inheritdoc/>
     public Task<string?> VectorSetGetAttributesJsonAsync(string key, string member, CommandFlags flag = CommandFlags.None) =>
@@ -47,4 +50,20 @@ public partial class RedisDatabase
     /// <inheritdoc/>
     public Task<RedisValue> VectorSetRandomMemberAsync(string key, CommandFlags flag = CommandFlags.None) =>
         Database.VectorSetRandomMemberAsync(key, flag);
+
+    /// <inheritdoc/>
+    public Task<RedisValue[]> VectorSetRandomMembersAsync(string key, long count, CommandFlags flag = CommandFlags.None) =>
+        Database.VectorSetRandomMembersAsync(key, count, flag);
+
+    /// <inheritdoc/>
+    public Task<Lease<float>?> VectorSetGetApproximateVectorAsync(string key, string member, CommandFlags flag = CommandFlags.None) =>
+        Database.VectorSetGetApproximateVectorAsync(key, member, flag);
+
+    /// <inheritdoc/>
+    public Task<Lease<RedisValue>?> VectorSetGetLinksAsync(string key, string member, CommandFlags flag = CommandFlags.None) =>
+        Database.VectorSetGetLinksAsync(key, member, flag);
+
+    /// <inheritdoc/>
+    public Task<Lease<VectorSetLink>?> VectorSetGetLinksWithScoresAsync(string key, string member, CommandFlags flag = CommandFlags.None) =>
+        Database.VectorSetGetLinksWithScoresAsync(key, member, flag);
 }


### PR DESCRIPTION
## Summary

Adds Redis VectorSet operations for AI/ML similarity search (Redis 8.0+).

Closes #631

## New API (10 methods)

| Method | Redis Command | Description |
|--------|--------------|-------------|
| `VectorSetAddAsync` | VADD | Add vector with optional JSON attributes |
| `VectorSetSimilaritySearchAsync` | VSIM | Similarity search (the core AI/ML operation) |
| `VectorSetRemoveAsync` | VREM | Remove member |
| `VectorSetContainsAsync` | VCONTAINS | Check membership |
| `VectorSetLengthAsync` | VCARD | Cardinality |
| `VectorSetDimensionAsync` | VDIM | Vector dimensions |
| `VectorSetGetAttributesJsonAsync` | VGETATTR | Get JSON metadata |
| `VectorSetSetAttributesJsonAsync` | VSETATTR | Set JSON metadata |
| `VectorSetInfoAsync` | VINFO | VectorSet info |
| `VectorSetRandomMemberAsync` | VRANDMEMBER | Random sampling |

## Example

```csharp
// Store embeddings
await redis.VectorSetAddAsync("products",
    VectorSetAddRequest.Create("shoe-123", embedding)
        .WithAttributes("""{"category":"shoes","price":99.99}"""));

// Similarity search
using var results = await redis.VectorSetSimilaritySearchAsync("products",
    VectorSetSimilaritySearchRequest.Create(queryEmbedding, count: 5));
```

## Documentation

New page: `doc/vectorset.md` with Mermaid diagrams and examples for RAG, recommendations, and semantic search.

## Test plan

- [ ] Build passes on all TFMs (net8.0, net9.0, net10.0, netstandard2.1)
- [ ] VectorSet tests require Redis 8.0+ (will add tests when Redis 8.0 is available in CI)