### PR TITLE
Implement milestone v12.5 — Core API Gaps

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <!-- General information -->
     <PropertyGroup>
         <Authors>Ugo Lattanzi</Authors>
-        <VersionPrefix>12.2.0</VersionPrefix>
+        <VersionPrefix>12.5.0</VersionPrefix>
         <!--
         <VersionSuffix>pre</VersionSuffix>
         -->
@@ -46,6 +46,14 @@ Features:
 Serializer packages (pick one): System.Text.Json, Newtonsoft, MemoryPack, MsgPack, Protobuf, ServiceStack, Utf8Json.
         </Description>
         <PackageReleaseNotes>
+v12.5.0:
+- Added IDistributedCache adapter with Hash-based storage compatible with Microsoft.Extensions.Caching.StackExchangeRedis (#632)
+- Added ASP.NET Core Health Check for Redis connection pool monitoring (#633)
+- Added StringIncrementAsync / StringDecrementAsync with long and double overloads (#634)
+- Added SetCombineAsync / SetCombineAndStoreAsync for union, intersect, and difference operations (#635)
+- Added Key Management: KeyRenameAsync, KeyTypeAsync, KeyDumpAsync, KeyRestoreAsync (#636)
+- Added .NET 8+ Keyed DI Services for named Redis clients via [FromKeyedServices] (#654)
+
 v12.2.0:
 - Fixed SearchKeysAsync ignoring database number — SCAN now correctly targets the specified database instead of always scanning DB0 (#651)
 - Fixed RemoveByTagAsync not deleting the tag Set key itself, causing a slow memory leak of empty tag Sets in Redis (#650)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -140,7 +140,7 @@ v12.0.0:
                           IncludeAssets="runtime; build; native; contentfiles; analyzer"/>
 
         <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers"
-                          Version="[17.14.*,18.0.0)"
+                          Version="[18.7.*,19.0.0)"
                           PrivateAssets="all"
                           IncludeAssets="runtime; build; native; contentfiles; analyzer"/>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/imperugo/StackExchange.Redis.Extensions/actions/workflows/ci.yml/badge.svg)](https://github.com/imperugo/StackExchange.Redis.Extensions/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/imperugo/StackExchange.Redis.Extensions/actions/workflows/codeql.yml/badge.svg)](https://github.com/imperugo/StackExchange.Redis.Extensions/actions/workflows/codeql.yml)
 [![NuGet](https://img.shields.io/nuget/v/StackExchange.Redis.Extensions.Core.svg?style=flat&label=NuGet)](https://www.nuget.org/packages/StackExchange.Redis.Extensions.Core/)
-![Tests](https://img.shields.io/badge/tests-970%2B%20passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-1100%2B%20passing-brightgreen)
 ![.NET](https://img.shields.io/badge/.NET-8%20%7C%209%20%7C%2010-blue)
 
 > **AI-Ready:** This library provides an [`llms.txt`](llms.txt) file for AI coding assistants and a Claude Code plugin for configuration, scaffolding, and troubleshooting.
@@ -24,12 +24,16 @@
 - Hash operations with per-field expiry (Redis 7.4+)
 - GeoSpatial indexes (GEOADD, GEOSEARCH, GEODIST, etc.)
 - Redis Streams with consumer group support
-- Set, List, and Sorted Set operations
+- Set, List, and Sorted Set operations with Set Combine (union, intersect, diff)
 - Key tagging and search
+- Key management (rename, type, dump/restore)
+- Atomic counters (StringIncrement/StringDecrement)
 - Transparent compression (GZip, Brotli, LZ4, Snappy, Zstandard)
+- `IDistributedCache` adapter (Microsoft-compatible Hash schema)
+- ASP.NET Core Health Check for connection pool monitoring
 - Azure Managed Identity support
-- ASP.NET Core integration with DI
-- Multiple named Redis instances
+- ASP.NET Core integration with DI and .NET 8+ Keyed Services
+- Multiple named Redis instances with `[FromKeyedServices]` support
 - OpenTelemetry integration
 - .NET Standard 2.1, .NET 8, .NET 9, .NET 10
 
@@ -221,6 +225,102 @@ await redis.SubscribeAsync<OrderEvent>("orders:new", async order =>
 await redis.PublishAsync("orders:new", new OrderEvent { Id = 42 });
 ```
 
+### Atomic Counters
+
+```csharp
+// Increment/decrement with long (default step = 1)
+var views = await redis.StringIncrementAsync("page:views");
+var stock = await redis.StringDecrementAsync("product:123:stock");
+
+// Custom step
+await redis.StringIncrementAsync("stats:bytes", 1024);
+
+// Double precision
+await redis.StringIncrementAsync("account:balance", 49.99);
+```
+
+### Set Operations
+
+```csharp
+// Combine sets: union, intersect, difference
+var allTags = await redis.SetCombineAsync<string>(SetOperation.Union, "user:1:tags", "user:2:tags");
+var commonTags = await redis.SetCombineAsync<string>(SetOperation.Intersect, "user:1:tags", "user:2:tags");
+
+// Store result in a new key
+await redis.SetCombineAndStoreAsync(SetOperation.Union, "all:tags", new[] { "set:a", "set:b", "set:c" });
+```
+
+### Key Management
+
+```csharp
+// Rename a key
+await redis.KeyRenameAsync("old-key", "new-key");
+
+// Check key type
+var type = await redis.KeyTypeAsync("my-key"); // RedisType.String, Set, Hash, ...
+
+// Dump and restore (migrate between databases)
+var dump = await redis.KeyDumpAsync("my-key");
+await redis.KeyRestoreAsync("my-key-copy", dump, TimeSpan.FromHours(1));
+```
+
+### IDistributedCache
+
+```csharp
+// Register the IDistributedCache adapter (call after AddStackExchangeRedisExtensions)
+builder.Services.AddStackExchangeRedisExtensions<SystemTextJsonSerializer>(redisConfig);
+builder.Services.AddRedisDistributedCache();
+
+// Use standard IDistributedCache anywhere
+public class MyService(IDistributedCache cache)
+{
+    public async Task CacheData()
+    {
+        await cache.SetAsync("session:abc", data, new DistributedCacheEntryOptions
+        {
+            SlidingExpiration = TimeSpan.FromMinutes(20),
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(4),
+        });
+
+        var cached = await cache.GetAsync("session:abc");
+    }
+}
+```
+
+> **Note:** Uses a Hash-based schema (`data`/`absexp`/`sldexp`) compatible with `Microsoft.Extensions.Caching.StackExchangeRedis`, enabling zero-downtime migration between providers.
+
+### Health Check
+
+```csharp
+// Register the health check
+builder.Services.AddHealthChecks()
+    .AddRedisExtensionsHealthCheck();
+
+// Returns:
+// - Healthy: all pool connections active + PING OK
+// - Degraded: some connections invalid but Redis responding
+// - Unhealthy: all connections invalid or PING fails
+```
+
+### Keyed DI Services (.NET 8+)
+
+```csharp
+// Register with named configurations
+builder.Services.AddStackExchangeRedisExtensions<SystemTextJsonSerializer>(new[]
+{
+    new RedisConfiguration { Name = "cache", IsDefault = true, /* ... */ },
+    new RedisConfiguration { Name = "session", /* ... */ },
+});
+
+// Inject by name using [FromKeyedServices]
+public class MyService(
+    [FromKeyedServices("cache")] IRedisDatabase cacheDb,
+    [FromKeyedServices("session")] IRedisDatabase sessionDb)
+{
+    // Each resolves to its own Redis instance with isolated connection pool
+}
+```
+
 ### Compression
 
 ```csharp
@@ -324,11 +424,13 @@ Full documentation is available in the [doc/](doc/) folder:
 - [Pub/Sub Messaging](doc/pubsub.md)
 - [Hash Field Expiry](doc/hash-field-expiry.md) (Redis 7.4+)
 - [Compression](doc/compressors.md) — GZip, Brotli, LZ4, Snappy, Zstandard
+- [Health Check](doc/health-check.md)
+- [IDistributedCache Adapter](doc/distributed-cache.md)
 
 **Advanced**
 - [Migration Guide: v11 → v12](doc/migration-v11-to-v12.md)
 - [Logging & Diagnostics](doc/logging.md)
-- [Multiple Redis Servers](doc/multipleServers.md)
+- [Multiple Redis Servers](doc/multipleServers.md) — including Keyed DI Services
 - [Azure Managed Identity](doc/azure-managed-identity.md)
 - [OpenTelemetry](doc/openTelemetry.md)
 - [Redis Information Middleware](doc/asp.net-core/expose-redis-information.md)

--- a/claude-plugin/skills/configure/SKILL.md
+++ b/claude-plugin/skills/configure/SKILL.md
@@ -75,7 +75,7 @@ var config = new RedisConfiguration
 };
 ```
 
-### Multiple instances
+### Multiple instances with Keyed DI (.NET 8+)
 ```csharp
 var configs = new[]
 {
@@ -84,7 +84,30 @@ var configs = new[]
 };
 builder.Services.AddStackExchangeRedisExtensions<SystemTextJsonSerializer>(configs);
 
-// Resolve: inject IRedisClientFactory, call GetRedisClient("Session")
+// Option 1: Keyed DI Services (.NET 8+)
+public class MyService(
+    [FromKeyedServices("Cache")] IRedisDatabase cacheDb,
+    [FromKeyedServices("Session")] IRedisDatabase sessionDb) { }
+
+// Option 2: Factory pattern (all TFMs)
+// inject IRedisClientFactory, call GetRedisClient("Session")
+```
+
+### Health Check
+```csharp
+builder.Services.AddHealthChecks()
+    .AddRedisExtensionsHealthCheck(
+        name: "redis",
+        tags: new[] { "db", "cache", "ready" });
+```
+
+### IDistributedCache adapter
+```csharp
+// Call after AddStackExchangeRedisExtensions
+builder.Services.AddRedisDistributedCache();
+
+// Uses Hash-based storage compatible with Microsoft.Extensions.Caching.StackExchangeRedis
+// Supports sliding expiration, absolute expiration, and refresh
 ```
 
 ### Key properties

--- a/claude-plugin/skills/diagnose/SKILL.md
+++ b/claude-plugin/skills/diagnose/SKILL.md
@@ -74,9 +74,27 @@ When the user reports:
 
 **Check:**
 1. **Pool health** — inject `IRedisClient` and call `client.ConnectionPoolManager.GetConnectionInformation()`
-2. **Redis server overloaded** — check `INFO clients` on Redis
-3. **Network partition** — the pool skips disconnected connections automatically and logs warnings
-4. **Dispose pattern** — ensure IRedisConnectionPoolManager is not disposed prematurely
+2. **Use health check** — register `builder.Services.AddHealthChecks().AddRedisExtensionsHealthCheck()` to monitor pool status automatically (returns Healthy/Degraded/Unhealthy)
+3. **Redis server overloaded** — check `INFO clients` on Redis
+4. **Network partition** — the pool skips disconnected connections automatically and logs warnings
+5. **Dispose pattern** — ensure IRedisConnectionPoolManager is not disposed prematurely
+
+### IDistributedCache Issues
+**Symptoms:** Data not found, expiration not working, migration issues
+
+**Check:**
+1. **Registration order** — `AddRedisDistributedCache()` must be called after `AddStackExchangeRedisExtensions<T>()`
+2. **KeyPrefix applies** — IDistributedCache goes through `IRedisDatabase.Database` which uses `WithKeyPrefix`. Cache keys are prefixed automatically.
+3. **Migration from Microsoft provider** — hash schema is compatible (`data`/`absexp`/`sldexp` fields), but key prefix format may differ (this library uses `KeyPrefix`, Microsoft uses `InstanceName`)
+4. **Sliding expiration not refreshing** — `Get` and `Refresh` both refresh the TTL. Check that `SlidingExpiration` was set in `DistributedCacheEntryOptions`
+
+### Keyed DI Not Resolving
+**Symptoms:** `[FromKeyedServices("name")]` returns null
+
+**Check:**
+1. **Config must have a Name** — `RedisConfiguration.Name` must be non-empty for keyed registration
+2. **Use eager overloads** — keyed services are only registered with the overloads that receive `RedisConfiguration` directly, NOT the `Func<IServiceProvider, ...>` overload
+3. **Name must match exactly** — `[FromKeyedServices("cache")]` must match `config.Name = "cache"` (case-sensitive)
 
 ### Performance Issues
 **Check:**

--- a/claude-plugin/skills/scaffold/SKILL.md
+++ b/claude-plugin/skills/scaffold/SKILL.md
@@ -15,7 +15,10 @@ When the user asks to implement:
 - VectorSet similarity search (RAG, recommendations)
 - Hash operations with per-field TTL
 - Pub/Sub messaging
-- Caching patterns (cache-aside, write-through)
+- Caching patterns (cache-aside, write-through, IDistributedCache)
+- Atomic counters (increment/decrement)
+- Set operations (union, intersect, difference)
+- Key management (rename, type, dump/restore)
 - Bulk operations
 
 ## Patterns
@@ -157,6 +160,70 @@ public async Task CacheBulkAsync(IRedisDatabase redis, Dictionary<string, Produc
 {
     var items = products.Select(p => Tuple.Create($"product:{p.Key}", p.Value)).ToArray();
     await redis.AddAllAsync(items, TimeSpan.FromHours(1));
+}
+```
+
+### Atomic Counters
+```csharp
+public class RateLimiter(IRedisDatabase redis)
+{
+    public async Task<bool> AllowRequestAsync(string clientId, int maxRequests, TimeSpan window)
+    {
+        var key = $"ratelimit:{clientId}";
+        var count = await redis.StringIncrementAsync(key);
+
+        if (count == 1)
+            await redis.UpdateExpiryAsync(key, window);
+
+        return count <= maxRequests;
+    }
+}
+```
+
+### Set Combine (Union, Intersect, Difference)
+```csharp
+public class TagService(IRedisDatabase redis)
+{
+    public async Task<string[]> GetCommonTagsAsync(string user1, string user2)
+    {
+        return await redis.SetCombineAsync<string>(
+            SetOperation.Intersect, $"user:{user1}:tags", $"user:{user2}:tags");
+    }
+
+    public async Task<long> MergeTagsAsync(string destination, params string[] sources)
+    {
+        return await redis.SetCombineAndStoreAsync(
+            SetOperation.Union, destination, sources);
+    }
+}
+```
+
+### Key Management
+```csharp
+// Rename with condition
+await redis.KeyRenameAsync("temp:data", "final:data", When.NotExists);
+
+// Check type before operations
+var type = await redis.KeyTypeAsync("my-key"); // RedisType.String, Set, Hash, ...
+
+// Dump and restore (migrate between databases)
+var dump = await redis.KeyDumpAsync("source-key");
+await redis.KeyRestoreAsync("dest-key", dump, TimeSpan.FromHours(24));
+```
+
+### IDistributedCache
+```csharp
+// Registered via: builder.Services.AddRedisDistributedCache()
+public class SessionService(IDistributedCache cache)
+{
+    public async Task SetAsync(string sessionId, byte[] data)
+    {
+        await cache.SetAsync($"session:{sessionId}", data, new DistributedCacheEntryOptions
+        {
+            SlidingExpiration = TimeSpan.FromMinutes(20),
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(4),
+        });
+    }
 }
 ```
 

--- a/doc/asp.net-core/README.md
+++ b/doc/asp.net-core/README.md
@@ -47,6 +47,27 @@ builder.Services.AddRedisCompression<LZ4Compressor>();
 
 See the [Compression](../compressors.md) page for all available compressors and configuration options.
 
+### Adding Health Check (optional)
+
+Monitor the Redis connection pool status through ASP.NET Core health checks:
+
+```csharp
+builder.Services.AddHealthChecks()
+    .AddRedisExtensionsHealthCheck();
+```
+
+Returns Healthy / Degraded / Unhealthy based on pool state and PING result. See [Health Check](../health-check.md) for details.
+
+### Adding IDistributedCache (optional)
+
+Use the standard `IDistributedCache` abstraction backed by the same Redis connection:
+
+```csharp
+builder.Services.AddRedisDistributedCache();
+```
+
+See [IDistributedCache Adapter](../distributed-cache.md) for sliding expiration behavior and storage format.
+
 ### Injecting IRedisDatabase
 
 Once registered, you can inject `IRedisDatabase` directly into your controllers, services, or minimal API handlers:

--- a/doc/distributed-cache.md
+++ b/doc/distributed-cache.md
@@ -1,0 +1,66 @@
+# IDistributedCache Adapter
+
+StackExchange.Redis.Extensions includes an `IDistributedCache` implementation that uses the same Redis connection pool managed by the library. This lets you use the standard Microsoft caching abstraction without adding a separate Redis connection.
+
+## Setup
+
+Register the adapter **after** `AddStackExchangeRedisExtensions`:
+
+```csharp
+builder.Services.AddStackExchangeRedisExtensions<SystemTextJsonSerializer>(redisConfig);
+builder.Services.AddRedisDistributedCache();
+```
+
+This registers `IDistributedCache` as a singleton backed by the default `IRedisDatabase`.
+
+## Usage
+
+Inject `IDistributedCache` anywhere:
+
+```csharp
+public class SessionService(IDistributedCache cache)
+{
+    public async Task<byte[]?> GetSessionAsync(string sessionId)
+    {
+        return await cache.GetAsync($"session:{sessionId}");
+    }
+
+    public async Task SetSessionAsync(string sessionId, byte[] data)
+    {
+        await cache.SetAsync($"session:{sessionId}", data, new DistributedCacheEntryOptions
+        {
+            SlidingExpiration = TimeSpan.FromMinutes(20),
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(4),
+        });
+    }
+}
+```
+
+## Expiration behavior
+
+| Option | Behavior |
+|--------|----------|
+| `SlidingExpiration` only | TTL resets on every `Get` or `Refresh` |
+| `AbsoluteExpiration` only | Fixed TTL, no refresh |
+| Both | TTL resets on access, capped by the absolute expiration |
+| Neither | Key persists until explicitly removed |
+
+## Storage format
+
+Data is stored as a Redis Hash with three fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data` | `byte[]` | The cached value |
+| `absexp` | `long` | Absolute expiration as UTC ticks (-1 if not set) |
+| `sldexp` | `long` | Sliding expiration as ticks (-1 if not set) |
+
+This schema is **compatible with `Microsoft.Extensions.Caching.StackExchangeRedis`**, enabling zero-downtime migration between providers.
+
+## Key prefix
+
+The adapter accesses Redis through `IRedisDatabase.Database`, which applies the `KeyPrefix` configured in `RedisConfiguration`. All distributed cache keys will be prefixed automatically.
+
+## Sync methods
+
+The `Get`, `Set`, `Remove`, and `Refresh` sync methods use the synchronous `IDatabase` methods directly (not `.GetAwaiter().GetResult()`), avoiding thread pool starvation.

--- a/doc/health-check.md
+++ b/doc/health-check.md
@@ -1,0 +1,52 @@
+# Health Check
+
+StackExchange.Redis.Extensions provides an ASP.NET Core health check that monitors the status of all Redis connection pools and verifies connectivity with a PING command.
+
+## Setup
+
+```csharp
+builder.Services.AddStackExchangeRedisExtensions<SystemTextJsonSerializer>(redisConfig);
+
+builder.Services.AddHealthChecks()
+    .AddRedisExtensionsHealthCheck();
+```
+
+## How it works
+
+The health check iterates all Redis clients registered via `IRedisClientFactory` and reports:
+
+| Status | Condition |
+|--------|-----------|
+| **Healthy** | All pool connections active, PING succeeds |
+| **Degraded** | Some pool connections invalid, but at least one active and PING succeeds |
+| **Unhealthy** | All connections invalid, or PING fails |
+
+Diagnostic data includes per-client pool details:
+
+```json
+{
+  "cache:active": 5,
+  "cache:invalid": 0,
+  "cache:required": 5,
+  "session:active": 3,
+  "session:invalid": 2,
+  "session:required": 5
+}
+```
+
+## Configuration
+
+The extension method accepts standard ASP.NET Core health check parameters:
+
+```csharp
+builder.Services.AddHealthChecks()
+    .AddRedisExtensionsHealthCheck(
+        name: "redis",
+        failureStatus: HealthStatus.Degraded,
+        tags: new[] { "db", "cache", "ready" },
+        timeout: TimeSpan.FromSeconds(5));
+```
+
+## Multiple Redis instances
+
+When multiple `RedisConfiguration` objects are registered (each with a unique `Name`), the health check inspects **all** of them. If any instance has invalid connections, the overall status reflects the worst case.

--- a/doc/multipleServers.md
+++ b/doc/multipleServers.md
@@ -34,25 +34,55 @@ var configurations = new[]
         services.AddStackExchangeRedisExtensions<SystemTextJsonSerializer>(configurations);
 ```
 
-Here the important things are the properties `IsDefault` and `Name`
+Here the important things are the properties `IsDefault` and `Name`.
 
-When you use `IRedisDatabase` you get the default connection but, if you want to connect to another one you can retrieve it using its name:
+Each named configuration gets its own isolated connection pool — there is no cross-contamination between instances.
+
+## Resolving named instances
+
+### Option 1: Keyed DI Services (.NET 8+)
+
+When you register configurations with a `Name`, the library automatically registers keyed singletons for `IRedisClient` and `IRedisDatabase`. You can inject them directly using `[FromKeyedServices]`:
 
 ```csharp
-public class MyClass
+public class MyService(
+    [FromKeyedServices("cache")] IRedisDatabase cacheDb,
+    [FromKeyedServices("session")] IRedisDatabase sessionDb)
 {
-    private readonly IRedisClientFactory clientFactory;
-    
-    public MyClass(IRedisClientFactory clientFactory)
+    public async Task Example()
     {
-        this.clientFactory = clientFactory;
+        await cacheDb.AddAsync("key", "value");
+        await sessionDb.AddAsync("session:abc", sessionData);
     }
-    
+}
+```
+
+This also works with minimal APIs:
+
+```csharp
+app.MapGet("/data", async ([FromKeyedServices("cache")] IRedisDatabase redis) =>
+{
+    return await redis.GetAsync<MyData>("key");
+});
+```
+
+> **Note:** Keyed services are only available when using the overloads that receive `RedisConfiguration` directly (not the `Func<IServiceProvider, ...>` overload), because the configuration names must be known at registration time.
+
+### Option 2: IRedisClientFactory
+
+If you're on .NET 8+ but prefer explicit resolution, or if you're on an older TFM, use `IRedisClientFactory`:
+
+```csharp
+public class MyClass(IRedisClientFactory clientFactory)
+{
     public Task MyMethod()
     {
-        var redisClient = clientFactory.GetRedisClient("Secndary Instance");
+        var redisClient = clientFactory.GetRedisClient("session");
+        var db = redisClient.GetDefaultDatabase();
         
         // do your stuff here
     }
 }
 ```
+
+Both approaches resolve to the same underlying `IRedisClient` instances.

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > A .NET library that extends StackExchange.Redis with object serialization, connection pooling, and higher-level APIs for Redis operations including Pub/Sub, Streams, GeoSpatial, VectorSet, Hash field expiry, and transparent compression.
 
-StackExchange.Redis.Extensions wraps the base StackExchange.Redis client library to make it easier to work with Redis in .NET applications. It supports .NET Standard 2.1, .NET 8, .NET 9, and .NET 10. All values are automatically serialized/deserialized through a pluggable ISerializer interface. Connection pooling with LeastLoaded and RoundRobin strategies is built-in.
+StackExchange.Redis.Extensions wraps the base StackExchange.Redis client library to make it easier to work with Redis in .NET applications. It supports .NET Standard 2.1, .NET 8, .NET 9, and .NET 10. All values are automatically serialized/deserialized through a pluggable ISerializer interface. Connection pooling with LeastLoaded and RoundRobin strategies is built-in. Includes IDistributedCache adapter, ASP.NET Core Health Check, .NET 8+ Keyed DI Services, atomic counters, Set Combine operations, and key management APIs.
 
 ## Core Documentation
 
@@ -26,6 +26,8 @@ StackExchange.Redis.Extensions wraps the base StackExchange.Redis client library
 - [Pub/Sub Messaging](https://raw.githubusercontent.com/imperugo/StackExchange.Redis.Extensions/master/doc/pubsub.md): Typed publish/subscribe with error handling
 - [Hash Field Expiry](https://raw.githubusercontent.com/imperugo/StackExchange.Redis.Extensions/master/doc/hash-field-expiry.md): Per-field TTL with HSETEX, HEXPIRE (Redis 7.4+)
 - [Compression](https://raw.githubusercontent.com/imperugo/StackExchange.Redis.Extensions/master/doc/compressors.md): LZ4, Snappier, Zstandard, GZip, Brotli
+- [Health Check](https://raw.githubusercontent.com/imperugo/StackExchange.Redis.Extensions/master/doc/health-check.md): ASP.NET Core health check monitoring connection pools
+- [IDistributedCache Adapter](https://raw.githubusercontent.com/imperugo/StackExchange.Redis.Extensions/master/doc/distributed-cache.md): Microsoft-compatible IDistributedCache with sliding expiration
 
 ## Serializers
 
@@ -36,7 +38,7 @@ StackExchange.Redis.Extensions wraps the base StackExchange.Redis client library
 ## Advanced
 
 - [Azure Managed Identity](https://raw.githubusercontent.com/imperugo/StackExchange.Redis.Extensions/master/doc/azure-managed-identity.md): ConfigurationOptionsAsyncHandler for Azure Cache
-- [Multiple Redis Servers](https://raw.githubusercontent.com/imperugo/StackExchange.Redis.Extensions/master/doc/multipleServers.md): Named Redis instances with IRedisClientFactory
+- [Multiple Redis Servers](https://raw.githubusercontent.com/imperugo/StackExchange.Redis.Extensions/master/doc/multipleServers.md): Named Redis instances with IRedisClientFactory and Keyed DI Services
 - [Logging & Diagnostics](https://raw.githubusercontent.com/imperugo/StackExchange.Redis.Extensions/master/doc/logging.md): Source-generated logging, event IDs, filtering
 - [OpenTelemetry](https://raw.githubusercontent.com/imperugo/StackExchange.Redis.Extensions/master/doc/openTelemetry.md): Distributed tracing integration
 - [ASP.NET Core Middleware](https://raw.githubusercontent.com/imperugo/StackExchange.Redis.Extensions/master/doc/asp.net-core/README.md): Integration and middleware setup

--- a/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/Caching/RedisDistributedCache.cs
+++ b/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/Caching/RedisDistributedCache.cs
@@ -30,24 +30,44 @@ internal sealed class RedisDistributedCache : IDistributedCache
     /// <param name="redisDatabase">The Redis database to use for caching.</param>
     public RedisDistributedCache(IRedisDatabase redisDatabase)
     {
+        if (redisDatabase is null)
+            throw new ArgumentNullException(nameof(redisDatabase));
+
         db = redisDatabase.Database;
     }
 
     /// <inheritdoc/>
     public byte[]? Get(string key)
     {
+        if (key is null)
+            throw new ArgumentNullException(nameof(key));
+
         return GetAndRefresh(key, getData: true);
     }
 
     /// <inheritdoc/>
     public Task<byte[]?> GetAsync(string key, CancellationToken token = default)
     {
+        if (key is null)
+            throw new ArgumentNullException(nameof(key));
+
+        token.ThrowIfCancellationRequested();
+
         return GetAndRefreshAsync(key, getData: true);
     }
 
     /// <inheritdoc/>
     public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
     {
+        if (key is null)
+            throw new ArgumentNullException(nameof(key));
+
+        if (value is null)
+            throw new ArgumentNullException(nameof(value));
+
+        if (options is null)
+            throw new ArgumentNullException(nameof(options));
+
         var absoluteExpiration = GetAbsoluteExpiration(options);
         var slidingTicks = options.SlidingExpiration?.Ticks ?? NotPresent;
 
@@ -69,6 +89,17 @@ internal sealed class RedisDistributedCache : IDistributedCache
     /// <inheritdoc/>
     public async Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
     {
+        if (key is null)
+            throw new ArgumentNullException(nameof(key));
+
+        if (value is null)
+            throw new ArgumentNullException(nameof(value));
+
+        if (options is null)
+            throw new ArgumentNullException(nameof(options));
+
+        token.ThrowIfCancellationRequested();
+
         var absoluteExpiration = GetAbsoluteExpiration(options);
         var slidingTicks = options.SlidingExpiration?.Ticks ?? NotPresent;
 
@@ -90,24 +121,40 @@ internal sealed class RedisDistributedCache : IDistributedCache
     /// <inheritdoc/>
     public void Remove(string key)
     {
+        if (key is null)
+            throw new ArgumentNullException(nameof(key));
+
         db.KeyDelete(key);
     }
 
     /// <inheritdoc/>
     public async Task RemoveAsync(string key, CancellationToken token = default)
     {
+        if (key is null)
+            throw new ArgumentNullException(nameof(key));
+
+        token.ThrowIfCancellationRequested();
+
         await db.KeyDeleteAsync(key).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public void Refresh(string key)
     {
+        if (key is null)
+            throw new ArgumentNullException(nameof(key));
+
         GetAndRefresh(key, getData: false);
     }
 
     /// <inheritdoc/>
     public async Task RefreshAsync(string key, CancellationToken token = default)
     {
+        if (key is null)
+            throw new ArgumentNullException(nameof(key));
+
+        token.ThrowIfCancellationRequested();
+
         await GetAndRefreshAsync(key, getData: false).ConfigureAwait(false);
     }
 
@@ -120,10 +167,7 @@ internal sealed class RedisDistributedCache : IDistributedCache
         else
             results = db.HashGet(key, [AbsoluteExpirationField, SlidingExpirationField]);
 
-        if (results.Length == 0)
-            return null;
-
-        if (getData && results[0].IsNull)
+        if (results[0].IsNull)
             return null;
 
         MapExpirationFields(results, getData, out var absExpTicks, out var sldExpTicks);
@@ -141,10 +185,7 @@ internal sealed class RedisDistributedCache : IDistributedCache
         else
             results = await db.HashGetAsync(key, [AbsoluteExpirationField, SlidingExpirationField]).ConfigureAwait(false);
 
-        if (results.Length == 0)
-            return null;
-
-        if (getData && results[0].IsNull)
+        if (results[0].IsNull)
             return null;
 
         MapExpirationFields(results, getData, out var absExpTicks, out var sldExpTicks);
@@ -205,7 +246,12 @@ internal sealed class RedisDistributedCache : IDistributedCache
     private static DateTimeOffset? GetAbsoluteExpiration(DistributedCacheEntryOptions options)
     {
         if (options.AbsoluteExpiration.HasValue)
+        {
+            if (options.AbsoluteExpiration.Value <= DateTimeOffset.UtcNow)
+                throw new ArgumentOutOfRangeException(nameof(options), options.AbsoluteExpiration.Value, "The absolute expiration value must be in the future.");
+
             return options.AbsoluteExpiration;
+        }
 
         if (options.AbsoluteExpirationRelativeToNow.HasValue)
             return DateTimeOffset.UtcNow.Add(options.AbsoluteExpirationRelativeToNow.Value);

--- a/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/Caching/RedisDistributedCache.cs
+++ b/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/Caching/RedisDistributedCache.cs
@@ -1,0 +1,232 @@
+// Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Caching.Distributed;
+
+using StackExchange.Redis.Extensions.Core.Abstractions;
+
+namespace StackExchange.Redis.Extensions.AspNetCore.Caching;
+
+/// <summary>
+/// An <see cref="IDistributedCache"/> implementation backed by StackExchange.Redis.Extensions.
+/// Uses a Hash-based storage format compatible with Microsoft.Extensions.Caching.StackExchangeRedis.
+/// </summary>
+internal sealed class RedisDistributedCache : IDistributedCache
+{
+    private const long NotPresent = -1;
+
+    private static readonly RedisValue DataField = "data";
+    private static readonly RedisValue AbsoluteExpirationField = "absexp";
+    private static readonly RedisValue SlidingExpirationField = "sldexp";
+
+    private readonly IDatabase db;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RedisDistributedCache"/> class.
+    /// </summary>
+    /// <param name="redisDatabase">The Redis database to use for caching.</param>
+    public RedisDistributedCache(IRedisDatabase redisDatabase)
+    {
+        db = redisDatabase.Database;
+    }
+
+    /// <inheritdoc/>
+    public byte[]? Get(string key)
+    {
+        return GetAndRefresh(key, getData: true);
+    }
+
+    /// <inheritdoc/>
+    public Task<byte[]?> GetAsync(string key, CancellationToken token = default)
+    {
+        return GetAndRefreshAsync(key, getData: true);
+    }
+
+    /// <inheritdoc/>
+    public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+    {
+        var absoluteExpiration = GetAbsoluteExpiration(options);
+        var slidingTicks = options.SlidingExpiration?.Ticks ?? NotPresent;
+
+        var fields = new HashEntry[]
+        {
+            new(DataField, value),
+            new(AbsoluteExpirationField, absoluteExpiration?.Ticks ?? NotPresent),
+            new(SlidingExpirationField, slidingTicks),
+        };
+
+        db.HashSet(key, fields);
+
+        var expiry = GetExpirationTimeout(absoluteExpiration, options.SlidingExpiration);
+
+        if (expiry.HasValue)
+            db.KeyExpire(key, expiry.Value);
+    }
+
+    /// <inheritdoc/>
+    public async Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+    {
+        var absoluteExpiration = GetAbsoluteExpiration(options);
+        var slidingTicks = options.SlidingExpiration?.Ticks ?? NotPresent;
+
+        var fields = new HashEntry[]
+        {
+            new(DataField, value),
+            new(AbsoluteExpirationField, absoluteExpiration?.Ticks ?? NotPresent),
+            new(SlidingExpirationField, slidingTicks),
+        };
+
+        await db.HashSetAsync(key, fields).ConfigureAwait(false);
+
+        var expiry = GetExpirationTimeout(absoluteExpiration, options.SlidingExpiration);
+
+        if (expiry.HasValue)
+            await db.KeyExpireAsync(key, expiry.Value).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public void Remove(string key)
+    {
+        db.KeyDelete(key);
+    }
+
+    /// <inheritdoc/>
+    public async Task RemoveAsync(string key, CancellationToken token = default)
+    {
+        await db.KeyDeleteAsync(key).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public void Refresh(string key)
+    {
+        GetAndRefresh(key, getData: false);
+    }
+
+    /// <inheritdoc/>
+    public async Task RefreshAsync(string key, CancellationToken token = default)
+    {
+        await GetAndRefreshAsync(key, getData: false).ConfigureAwait(false);
+    }
+
+    private byte[]? GetAndRefresh(string key, bool getData)
+    {
+        RedisValue[] results;
+
+        if (getData)
+            results = db.HashGet(key, [DataField, AbsoluteExpirationField, SlidingExpirationField]);
+        else
+            results = db.HashGet(key, [AbsoluteExpirationField, SlidingExpirationField]);
+
+        if (results.Length == 0)
+            return null;
+
+        if (getData && results[0].IsNull)
+            return null;
+
+        MapExpirationFields(results, getData, out var absExpTicks, out var sldExpTicks);
+        RefreshExpiration(key, absExpTicks, sldExpTicks);
+
+        return getData ? (byte[]?)results[0] : null;
+    }
+
+    private async Task<byte[]?> GetAndRefreshAsync(string key, bool getData)
+    {
+        RedisValue[] results;
+
+        if (getData)
+            results = await db.HashGetAsync(key, [DataField, AbsoluteExpirationField, SlidingExpirationField]).ConfigureAwait(false);
+        else
+            results = await db.HashGetAsync(key, [AbsoluteExpirationField, SlidingExpirationField]).ConfigureAwait(false);
+
+        if (results.Length == 0)
+            return null;
+
+        if (getData && results[0].IsNull)
+            return null;
+
+        MapExpirationFields(results, getData, out var absExpTicks, out var sldExpTicks);
+        await RefreshExpirationAsync(key, absExpTicks, sldExpTicks).ConfigureAwait(false);
+
+        return getData ? (byte[]?)results[0] : null;
+    }
+
+    private static void MapExpirationFields(RedisValue[] results, bool getData, out long absExpTicks, out long sldExpTicks)
+    {
+        var offset = getData ? 1 : 0;
+        absExpTicks = (long)results[offset];
+        sldExpTicks = (long)results[offset + 1];
+    }
+
+    private void RefreshExpiration(string key, long absExpTicks, long sldExpTicks)
+    {
+        if (sldExpTicks == NotPresent)
+            return;
+
+        var expiry = CalculateNewExpiry(absExpTicks, sldExpTicks);
+
+        if (expiry.HasValue)
+            db.KeyExpire(key, expiry.Value);
+    }
+
+    private async Task RefreshExpirationAsync(string key, long absExpTicks, long sldExpTicks)
+    {
+        if (sldExpTicks == NotPresent)
+            return;
+
+        var expiry = CalculateNewExpiry(absExpTicks, sldExpTicks);
+
+        if (expiry.HasValue)
+            await db.KeyExpireAsync(key, expiry.Value).ConfigureAwait(false);
+    }
+
+    private static TimeSpan? CalculateNewExpiry(long absExpTicks, long sldExpTicks)
+    {
+        var utcNow = DateTimeOffset.UtcNow;
+        var sliding = TimeSpan.FromTicks(sldExpTicks);
+        var newExpiration = utcNow.Add(sliding);
+
+        if (absExpTicks != NotPresent)
+        {
+            var absoluteExpiration = new DateTimeOffset(absExpTicks, TimeSpan.Zero);
+
+            if (absoluteExpiration <= utcNow)
+                return null;
+
+            if (newExpiration > absoluteExpiration)
+                newExpiration = absoluteExpiration;
+        }
+
+        return newExpiration - utcNow;
+    }
+
+    private static DateTimeOffset? GetAbsoluteExpiration(DistributedCacheEntryOptions options)
+    {
+        if (options.AbsoluteExpiration.HasValue)
+            return options.AbsoluteExpiration;
+
+        if (options.AbsoluteExpirationRelativeToNow.HasValue)
+            return DateTimeOffset.UtcNow.Add(options.AbsoluteExpirationRelativeToNow.Value);
+
+        return null;
+    }
+
+    private static TimeSpan? GetExpirationTimeout(DateTimeOffset? absoluteExpiration, TimeSpan? slidingExpiration)
+    {
+        if (absoluteExpiration.HasValue && slidingExpiration.HasValue)
+        {
+            var remaining = absoluteExpiration.Value - DateTimeOffset.UtcNow;
+            return remaining < slidingExpiration.Value ? remaining : slidingExpiration.Value;
+        }
+
+        if (absoluteExpiration.HasValue)
+            return absoluteExpiration.Value - DateTimeOffset.UtcNow;
+
+        if (slidingExpiration.HasValue)
+            return slidingExpiration.Value;
+
+        return null;
+    }
+}

--- a/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/Extensions/IHealthChecksBuilderExtensions.cs
+++ b/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/Extensions/IHealthChecksBuilderExtensions.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+using StackExchange.Redis.Extensions.AspNetCore.HealthChecks;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for adding Redis health checks.
+/// </summary>
+public static class IHealthChecksBuilderExtensions
+{
+    /// <summary>
+    /// Adds a health check for the Redis connection pool managed by StackExchange.Redis.Extensions.
+    /// The check verifies connection pool status across all registered Redis instances and performs a PING.
+    /// </summary>
+    /// <param name="builder">The health checks builder.</param>
+    /// <param name="name">The name of the health check (default: "redis").</param>
+    /// <param name="failureStatus">The <see cref="HealthStatus"/> to report when the health check fails (default: <see cref="HealthStatus.Unhealthy"/>).</param>
+    /// <param name="tags">Optional tags for filtering health checks.</param>
+    /// <param name="timeout">Optional timeout for the health check.</param>
+    /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+    public static IHealthChecksBuilder AddRedisExtensionsHealthCheck(
+        this IHealthChecksBuilder builder,
+        string name = "redis",
+        HealthStatus? failureStatus = null,
+        IEnumerable<string>? tags = null,
+        System.TimeSpan? timeout = null)
+    {
+        return builder.AddCheck<RedisHealthCheck>(name, failureStatus, tags, timeout);
+    }
+}

--- a/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/Extensions/IServiceCollectionDistributedCacheExtensions.cs
+++ b/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/Extensions/IServiceCollectionDistributedCacheExtensions.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Caching.Distributed;
+
+using StackExchange.Redis.Extensions.AspNetCore.Caching;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for registering <see cref="IDistributedCache"/> backed by StackExchange.Redis.Extensions.
+/// </summary>
+public static class IServiceCollectionDistributedCacheExtensions
+{
+    /// <summary>
+    /// Registers <see cref="IDistributedCache"/> using the Redis connection managed by StackExchange.Redis.Extensions.
+    /// Must be called after <see cref="IServiceCollectionExtensions.AddStackExchangeRedisExtensions{T}(IServiceCollection, StackExchange.Redis.Extensions.Core.Configuration.RedisConfiguration)"/>.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The <see cref="IServiceCollection"/> for chaining.</returns>
+    public static IServiceCollection AddRedisDistributedCache(this IServiceCollection services)
+    {
+        services.AddSingleton<IDistributedCache, RedisDistributedCache>();
+        return services;
+    }
+}

--- a/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/Extensions/IServiceCollectionExtensions.cs
+++ b/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/Extensions/IServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using StackExchange.Redis.Extensions.Core;
 using StackExchange.Redis.Extensions.Core.Abstractions;
@@ -17,6 +18,8 @@ public static class IServiceCollectionExtensions
 {
     /// <summary>
     /// Add StackExchange.Redis with its serialization provider.
+    /// When the configuration has a non-empty <see cref="RedisConfiguration.Name"/>, keyed services for
+    /// <see cref="IRedisClient"/> and <see cref="IRedisDatabase"/> are registered automatically.
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <param name="redisConfiguration">The redis configration.</param>
@@ -26,21 +29,36 @@ public static class IServiceCollectionExtensions
         RedisConfiguration redisConfiguration)
         where T : class, ISerializer
     {
-        return services.AddStackExchangeRedisExtensions<T>(sp => [redisConfiguration]);
+        return services.AddStackExchangeRedisExtensions<T>([redisConfiguration]);
     }
 
     /// <summary>
     /// Add StackExchange.Redis with its serialization provider.
+    /// When configurations have a non-empty <see cref="RedisConfiguration.Name"/>, keyed services for
+    /// <see cref="IRedisClient"/> and <see cref="IRedisDatabase"/> are registered automatically.
     /// </summary>
     /// <param name="services">The service collection.</param>
-    /// <param name="redisConfiguration">The redis configration.</param>
+    /// <param name="redisConfigurations">The redis configrations.</param>
     /// <typeparam name="T">The typof of serializer. <see cref="ISerializer" />.</typeparam>
     public static IServiceCollection AddStackExchangeRedisExtensions<T>(
         this IServiceCollection services,
-        IEnumerable<RedisConfiguration> redisConfiguration)
+        IEnumerable<RedisConfiguration> redisConfigurations)
         where T : class, ISerializer
     {
-        return services.AddStackExchangeRedisExtensions<T>(sp => redisConfiguration);
+        services.AddStackExchangeRedisExtensions<T>(sp => redisConfigurations);
+
+        foreach (var config in redisConfigurations.Where(c => !string.IsNullOrEmpty(c.Name)))
+        {
+            var name = config.Name;
+
+            services.AddKeyedSingleton<IRedisClient>(name,
+                (sp, _) => sp.GetRequiredService<IRedisClientFactory>().GetRedisClient(name));
+
+            services.AddKeyedSingleton<IRedisDatabase>(name,
+                (sp, _) => sp.GetRequiredService<IRedisClientFactory>().GetRedisDatabase(name));
+        }
+
+        return services;
     }
 
     /// <summary>
@@ -49,6 +67,11 @@ public static class IServiceCollectionExtensions
     /// <param name="services">The service collection.</param>
     /// <param name="redisConfigurationFactory">The redis configration factory.</param>
     /// <typeparam name="T">The typof of serializer. <see cref="ISerializer" />.</typeparam>
+    /// <remarks>
+    /// Keyed DI services are not registered when using this overload because configuration names are
+    /// not available at registration time. Use the overloads accepting <see cref="RedisConfiguration"/>
+    /// or <see cref="IEnumerable{RedisConfiguration}"/> to get keyed service support.
+    /// </remarks>
     public static IServiceCollection AddStackExchangeRedisExtensions<T>(
         this IServiceCollection services,
         Func<IServiceProvider, IEnumerable<RedisConfiguration>> redisConfigurationFactory)

--- a/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/HealthChecks/RedisHealthCheck.cs
+++ b/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/HealthChecks/RedisHealthCheck.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+using StackExchange.Redis.Extensions.Core.Abstractions;
+
+namespace StackExchange.Redis.Extensions.AspNetCore.HealthChecks;
+
+internal sealed class RedisHealthCheck(IRedisClientFactory redisClientFactory) : IHealthCheck
+{
+    /// <inheritdoc/>
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        var data = new Dictionary<string, object>();
+        var allHealthy = true;
+        var anyHealthy = false;
+
+        foreach (var client in redisClientFactory.GetAllClients())
+        {
+            var name = client.Name;
+            var info = client.ConnectionPoolManager.GetConnectionInformation();
+
+            data[$"{name}:active_connections"] = info.ActiveConnections;
+            data[$"{name}:invalid_connections"] = info.InvalidConnections;
+            data[$"{name}:required_pool_size"] = info.RequiredPoolSize;
+
+            if (info.InvalidConnections > 0)
+                allHealthy = false;
+
+            if (info.ActiveConnections > 0)
+                anyHealthy = true;
+        }
+
+        if (!anyHealthy)
+            return HealthCheckResult.Unhealthy("All Redis connections are invalid.", data: data);
+
+        try
+        {
+            var db = redisClientFactory.GetDefaultRedisDatabase().Database;
+            var ping = await db.PingAsync().ConfigureAwait(false);
+            data["ping_ms"] = ping.TotalMilliseconds;
+        }
+        catch (RedisException ex)
+        {
+            return HealthCheckResult.Unhealthy("Redis PING failed.", ex, data);
+        }
+        catch (RedisTimeoutException ex)
+        {
+            return HealthCheckResult.Unhealthy("Redis PING timed out.", ex, data);
+        }
+
+        if (!allHealthy)
+            return HealthCheckResult.Degraded("Some Redis connections are invalid.", data: data);
+
+        return HealthCheckResult.Healthy("All Redis connections are active.", data: data);
+    }
+}

--- a/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/HealthChecks/RedisHealthCheck.cs
+++ b/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/HealthChecks/RedisHealthCheck.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,11 +17,17 @@ internal sealed class RedisHealthCheck(IRedisClientFactory redisClientFactory) :
     /// <inheritdoc/>
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var data = new Dictionary<string, object>();
         var allHealthy = true;
         var anyHealthy = false;
+        var clients = redisClientFactory.GetAllClients().ToList();
 
-        foreach (var client in redisClientFactory.GetAllClients())
+        if (clients.Count == 0)
+            return HealthCheckResult.Unhealthy("No Redis clients are configured.", data: data);
+
+        foreach (var client in clients)
         {
             var name = client.Name;
             var info = client.ConnectionPoolManager.GetConnectionInformation();
@@ -34,25 +41,38 @@ internal sealed class RedisHealthCheck(IRedisClientFactory redisClientFactory) :
 
             if (info.ActiveConnections > 0)
                 anyHealthy = true;
+
+            if (info.ActiveConnections > 0)
+            {
+                try
+                {
+                    var db = client.GetDefaultDatabase().Database;
+                    var ping = await db.PingAsync().ConfigureAwait(false);
+                    data[$"{name}:ping_ms"] = ping.TotalMilliseconds;
+                }
+                catch (RedisConnectionException ex)
+                {
+                    allHealthy = false;
+                    data[$"{name}:ping"] = "connection_failed";
+                    return HealthCheckResult.Unhealthy($"Redis PING failed for '{name}': connection error.", ex, data);
+                }
+                catch (RedisException ex)
+                {
+                    allHealthy = false;
+                    data[$"{name}:ping"] = "failed";
+                    return HealthCheckResult.Unhealthy($"Redis PING failed for '{name}'.", ex, data);
+                }
+                catch (RedisTimeoutException ex)
+                {
+                    allHealthy = false;
+                    data[$"{name}:ping"] = "timed_out";
+                    return HealthCheckResult.Unhealthy($"Redis PING timed out for '{name}'.", ex, data);
+                }
+            }
         }
 
         if (!anyHealthy)
             return HealthCheckResult.Unhealthy("All Redis connections are invalid.", data: data);
-
-        try
-        {
-            var db = redisClientFactory.GetDefaultRedisDatabase().Database;
-            var ping = await db.PingAsync().ConfigureAwait(false);
-            data["ping_ms"] = ping.TotalMilliseconds;
-        }
-        catch (RedisException ex)
-        {
-            return HealthCheckResult.Unhealthy("Redis PING failed.", ex, data);
-        }
-        catch (RedisTimeoutException ex)
-        {
-            return HealthCheckResult.Unhealthy("Redis PING timed out.", ex, data);
-        }
 
         if (!allHealthy)
             return HealthCheckResult.Degraded("Some Redis connections are invalid.", data: data);

--- a/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/StackExchange.Redis.Extensions.AspNetCore.csproj
+++ b/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/StackExchange.Redis.Extensions.AspNetCore.csproj
@@ -17,8 +17,5 @@
     <ProjectReference Include="..\..\core\StackExchange.Redis.Extensions.Core\StackExchange.Redis.Extensions.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles" />
-  </ItemGroup>
 
 </Project>

--- a/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/StackExchange.Redis.Extensions.AspNetCore.csproj
+++ b/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/StackExchange.Redis.Extensions.AspNetCore.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="StackExchange.Redis.Extensions.Core.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\..\core\StackExchange.Redis.Extensions.Core\StackExchange.Redis.Extensions.Core.csproj" />
   </ItemGroup>

--- a/src/compressors/StackExchange.Redis.Extensions.Compression.Brotli/StackExchange.Redis.Extensions.Compression.Brotli.csproj
+++ b/src/compressors/StackExchange.Redis.Extensions.Compression.Brotli/StackExchange.Redis.Extensions.Compression.Brotli.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/compressors/StackExchange.Redis.Extensions.Compression.GZip/StackExchange.Redis.Extensions.Compression.GZip.csproj
+++ b/src/compressors/StackExchange.Redis.Extensions.Compression.GZip/StackExchange.Redis.Extensions.Compression.GZip.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/compressors/StackExchange.Redis.Extensions.Compression.LZ4/StackExchange.Redis.Extensions.Compression.LZ4.csproj
+++ b/src/compressors/StackExchange.Redis.Extensions.Compression.LZ4/StackExchange.Redis.Extensions.Compression.LZ4.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="K4os.Compression.LZ4" Version="[1.3.*,2.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/compressors/StackExchange.Redis.Extensions.Compression.Snappier/StackExchange.Redis.Extensions.Compression.Snappier.csproj
+++ b/src/compressors/StackExchange.Redis.Extensions.Compression.Snappier/StackExchange.Redis.Extensions.Compression.Snappier.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Snappier" Version="[1.3.*,2.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/compressors/StackExchange.Redis.Extensions.Compression.ZstdSharp/StackExchange.Redis.Extensions.Compression.ZstdSharp.csproj
+++ b/src/compressors/StackExchange.Redis.Extensions.Compression.ZstdSharp/StackExchange.Redis.Extensions.Compression.ZstdSharp.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="ZstdSharp.Port" Version="[0.8.*,1.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/core/StackExchange.Redis.Extensions.Core/Abstractions/IRedisClient.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Abstractions/IRedisClient.cs
@@ -135,7 +135,12 @@ public interface IRedisClient
     IRedisConnectionPoolManager ConnectionPoolManager { get; }
 
     /// <summary>
+    /// The default name used when no explicit name is configured.
+    /// </summary>
+    const string DefaultName = "default";
+
+    /// <summary>
     /// Gets the name of this Redis client as defined in <see cref="Configuration.RedisConfiguration.Name"/>.
     /// </summary>
-    string Name => "default";
+    string Name => DefaultName;
 }

--- a/src/core/StackExchange.Redis.Extensions.Core/Abstractions/IRedisClient.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Abstractions/IRedisClient.cs
@@ -133,4 +133,9 @@ public interface IRedisClient
     /// Returns an instance <see cref="ConnectionPoolManager"/> that handles the connection pooling.
     /// </summary>
     IRedisConnectionPoolManager ConnectionPoolManager { get; }
+
+    /// <summary>
+    /// Gets the name of this Redis client as defined in <see cref="Configuration.RedisConfiguration.Name"/>.
+    /// </summary>
+    string Name => "default";
 }

--- a/src/core/StackExchange.Redis.Extensions.Core/Abstractions/IRedisDatabase.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Abstractions/IRedisDatabase.cs
@@ -331,6 +331,52 @@ public partial interface IRedisDatabase
     public Task<T[]> SetMembersAsync<T>(string key, CommandFlags flag = CommandFlags.None);
 
     /// <summary>
+    ///     Run SUNION/SINTER/SDIFF command. See https://redis.io/commands/sunion, https://redis.io/commands/sinter, https://redis.io/commands/sdiff
+    ///     Returns the result of the specified set operation between two sets, deserializing each member to <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the expected objects in the set</typeparam>
+    /// <param name="operation">The set operation to perform (Union, Intersect, Difference)</param>
+    /// <param name="firstKey">The key of the first set</param>
+    /// <param name="secondKey">The key of the second set</param>
+    /// <param name="flag">Behaviour markers associated with a given command</param>
+    /// <returns>An array of deserialized objects resulting from the set operation</returns>
+    public Task<T[]> SetCombineAsync<T>(SetOperation operation, string firstKey, string secondKey, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Run SUNION/SINTER/SDIFF command. See https://redis.io/commands/sunion, https://redis.io/commands/sinter, https://redis.io/commands/sdiff
+    ///     Returns the result of the specified set operation between multiple sets, deserializing each member to <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the expected objects in the set</typeparam>
+    /// <param name="operation">The set operation to perform (Union, Intersect, Difference)</param>
+    /// <param name="keys">The keys of the sets to combine</param>
+    /// <param name="flag">Behaviour markers associated with a given command</param>
+    /// <returns>An array of deserialized objects resulting from the set operation</returns>
+    public Task<T[]> SetCombineAsync<T>(SetOperation operation, string[] keys, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Run SUNIONSTORE/SINTERSTORE/SDIFFSTORE command. See https://redis.io/commands/sunionstore, https://redis.io/commands/sinterstore, https://redis.io/commands/sdiffstore
+    ///     Performs the specified set operation between two sets and stores the result in the destination key.
+    /// </summary>
+    /// <param name="operation">The set operation to perform (Union, Intersect, Difference)</param>
+    /// <param name="destinationKey">The key where the result will be stored</param>
+    /// <param name="firstKey">The key of the first set</param>
+    /// <param name="secondKey">The key of the second set</param>
+    /// <param name="flag">Behaviour markers associated with a given command</param>
+    /// <returns>The number of elements in the resulting set</returns>
+    public Task<long> SetCombineAndStoreAsync(SetOperation operation, string destinationKey, string firstKey, string secondKey, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Run SUNIONSTORE/SINTERSTORE/SDIFFSTORE command. See https://redis.io/commands/sunionstore, https://redis.io/commands/sinterstore, https://redis.io/commands/sdiffstore
+    ///     Performs the specified set operation between multiple sets and stores the result in the destination key.
+    /// </summary>
+    /// <param name="operation">The set operation to perform (Union, Intersect, Difference)</param>
+    /// <param name="destinationKey">The key where the result will be stored</param>
+    /// <param name="keys">The keys of the sets to combine</param>
+    /// <param name="flag">Behaviour markers associated with a given command</param>
+    /// <returns>The number of elements in the resulting set</returns>
+    public Task<long> SetCombineAndStoreAsync(SetOperation operation, string destinationKey, string[] keys, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
     ///     Searches the keys from Redis database
     /// </summary>
     /// <remarks>
@@ -402,4 +448,87 @@ public partial interface IRedisDatabase
     /// <param name="flag">Behaviour markers associated with a given command</param>
     /// <returns>An IDictionary object that contains the original key and the result of the operation</returns>
     public Task<IDictionary<string, bool>> UpdateExpiryAllAsync(HashSet<string> keys, TimeSpan expiresIn, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Increments the number stored at key by <paramref name="value"/>.
+    ///     If the key does not exist, it is set to 0 before performing the operation.
+    ///     Run INCRBY command https://redis.io/commands/incrby
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="value">The amount to increment by (default 1).</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The value of key after the increment.</returns>
+    public Task<long> StringIncrementAsync(string key, long value = 1, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Decrements the number stored at key by <paramref name="value"/>.
+    ///     If the key does not exist, it is set to 0 before performing the operation.
+    ///     Run DECRBY command https://redis.io/commands/decrby
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="value">The amount to decrement by (default 1).</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The value of key after the decrement.</returns>
+    public Task<long> StringDecrementAsync(string key, long value = 1, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Increments the floating point number stored at key by <paramref name="value"/>.
+    ///     If the key does not exist, it is set to 0 before performing the operation.
+    ///     Run INCRBYFLOAT command https://redis.io/commands/incrbyfloat
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="value">The amount to increment by.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The value of key after the increment.</returns>
+    public Task<double> StringIncrementAsync(string key, double value, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Decrements the floating point number stored at key by <paramref name="value"/>.
+    ///     If the key does not exist, it is set to 0 before performing the operation.
+    ///     There is no DECRBYFLOAT command; this is implemented via INCRBYFLOAT with a negated value.
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="value">The amount to decrement by.</param>
+    /// <param name="flag">Behaviour markers associated with a given command.</param>
+    /// <returns>The value of key after the decrement.</returns>
+    public Task<double> StringDecrementAsync(string key, double value, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Renames the specified key.
+    ///     Run RENAME command https://redis.io/commands/rename
+    /// </summary>
+    /// <param name="key">The key to rename.</param>
+    /// <param name="newKey">The new name for the key.</param>
+    /// <param name="when">The condition under which the rename should occur (Always is the default value).</param>
+    /// <param name="flag">Behaviour markers associated with a given command</param>
+    /// <returns>True if the key was renamed. Otherwise false</returns>
+    public Task<bool> KeyRenameAsync(string key, string newKey, When when = When.Always, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Returns the type of the value stored at the specified key.
+    ///     Run TYPE command https://redis.io/commands/type
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="flag">Behaviour markers associated with a given command</param>
+    /// <returns>The <see cref="RedisType"/> of the key, or <see cref="RedisType.None"/> when the key does not exist.</returns>
+    public Task<RedisType> KeyTypeAsync(string key, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Serializes the value stored at the specified key in a Redis-specific format and returns it.
+    ///     Run DUMP command https://redis.io/commands/dump
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="flag">Behaviour markers associated with a given command</param>
+    /// <returns>The serialized value as a byte array, or null if the key does not exist.</returns>
+    public Task<byte[]?> KeyDumpAsync(string key, CommandFlags flag = CommandFlags.None);
+
+    /// <summary>
+    ///     Creates a key associated with a value that is obtained by deserializing the provided serialized value (obtained via DUMP).
+    ///     Run RESTORE command https://redis.io/commands/restore
+    /// </summary>
+    /// <param name="key">The cache key.</param>
+    /// <param name="value">The serialized value previously obtained using <see cref="KeyDumpAsync"/>.</param>
+    /// <param name="expiry">The optional expiry to set on the key.</param>
+    /// <param name="flag">Behaviour markers associated with a given command</param>
+    public Task KeyRestoreAsync(string key, byte[] value, TimeSpan? expiry = null, CommandFlags flag = CommandFlags.None);
 }

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisClient.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisClient.cs
@@ -108,4 +108,7 @@ public class RedisClient : IRedisClient
 
     /// <inheritdoc/>
     public IRedisConnectionPoolManager ConnectionPoolManager { get; }
+
+    /// <inheritdoc/>
+    public string Name => redisConfiguration.Name ?? "default";
 }

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisClient.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisClient.cs
@@ -110,5 +110,5 @@ public class RedisClient : IRedisClient
     public IRedisConnectionPoolManager ConnectionPoolManager { get; }
 
     /// <inheritdoc/>
-    public string Name => redisConfiguration.Name ?? "default";
+    public string Name => redisConfiguration.Name ?? IRedisClient.DefaultName;
 }

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
@@ -476,6 +476,37 @@ public partial class RedisDatabase : IRedisDatabase
     }
 
     /// <inheritdoc/>
+    public async Task<T[]> SetCombineAsync<T>(SetOperation operation, string firstKey, string secondKey, CommandFlags flag = CommandFlags.None)
+    {
+        var members = await Database.SetCombineAsync(operation, firstKey, secondKey, flag).ConfigureAwait(false);
+
+        if (members.Length == 0)
+            return [];
+
+        return members.ToFastArray(m => Serializer.Deserialize<T>(m)!);
+    }
+
+    /// <inheritdoc/>
+    public async Task<T[]> SetCombineAsync<T>(SetOperation operation, string[] keys, CommandFlags flag = CommandFlags.None)
+    {
+        var redisKeys = keys.ToFastArray(k => (RedisKey)k);
+        var members = await Database.SetCombineAsync(operation, redisKeys, flag).ConfigureAwait(false);
+
+        if (members.Length == 0)
+            return [];
+
+        return members.ToFastArray(m => Serializer.Deserialize<T>(m)!);
+    }
+
+    /// <inheritdoc/>
+    public Task<long> SetCombineAndStoreAsync(SetOperation operation, string destinationKey, string firstKey, string secondKey, CommandFlags flag = CommandFlags.None)
+        => Database.SetCombineAndStoreAsync(operation, destinationKey, firstKey, secondKey, flag);
+
+    /// <inheritdoc/>
+    public Task<long> SetCombineAndStoreAsync(SetOperation operation, string destinationKey, string[] keys, CommandFlags flag = CommandFlags.None)
+        => Database.SetCombineAndStoreAsync(operation, destinationKey, keys.ToFastArray(k => (RedisKey)k), flag);
+
+    /// <inheritdoc/>
     public async Task<IEnumerable<string>> SearchKeysAsync(string pattern)
     {
         pattern = $"{keyPrefix}{pattern}";
@@ -550,6 +581,38 @@ public partial class RedisDatabase : IRedisDatabase
         var entryBytes = Serializer.Serialize(value);
         return Database.SortedSetIncrementAsync(key, entryBytes, score, flag);
     }
+
+    /// <inheritdoc/>
+    public Task<long> StringIncrementAsync(string key, long value = 1, CommandFlags flag = CommandFlags.None)
+        => Database.StringIncrementAsync(key, value, flag);
+
+    /// <inheritdoc/>
+    public Task<long> StringDecrementAsync(string key, long value = 1, CommandFlags flag = CommandFlags.None)
+        => Database.StringDecrementAsync(key, value, flag);
+
+    /// <inheritdoc/>
+    public Task<double> StringIncrementAsync(string key, double value, CommandFlags flag = CommandFlags.None)
+        => Database.StringIncrementAsync(key, value, flag);
+
+    /// <inheritdoc/>
+    public Task<double> StringDecrementAsync(string key, double value, CommandFlags flag = CommandFlags.None)
+        => Database.StringDecrementAsync(key, value, flag);
+
+    /// <inheritdoc/>
+    public Task<bool> KeyRenameAsync(string key, string newKey, When when = When.Always, CommandFlags flag = CommandFlags.None)
+        => Database.KeyRenameAsync(key, newKey, when, flag);
+
+    /// <inheritdoc/>
+    public Task<RedisType> KeyTypeAsync(string key, CommandFlags flag = CommandFlags.None)
+        => Database.KeyTypeAsync(key, flag);
+
+    /// <inheritdoc/>
+    public Task<byte[]?> KeyDumpAsync(string key, CommandFlags flag = CommandFlags.None)
+        => Database.KeyDumpAsync(key, flag);
+
+    /// <inheritdoc/>
+    public Task KeyRestoreAsync(string key, byte[] value, TimeSpan? expiry = null, CommandFlags flag = CommandFlags.None)
+        => Database.KeyRestoreAsync(key, value, expiry, flag);
 
     private static Dictionary<string, string> ParseInfo(string info)
     {

--- a/src/core/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.csproj
+++ b/src/core/StackExchange.Redis.Extensions.Core/StackExchange.Redis.Extensions.Core.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/src/serializers/StackExchange.Redis.Extensions.MemoryPack/StackExchange.Redis.Extensions.MemoryPack.csproj
+++ b/src/serializers/StackExchange.Redis.Extensions.MemoryPack/StackExchange.Redis.Extensions.MemoryPack.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="MemoryPack" Version="[1.21.4,2.0.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/serializers/StackExchange.Redis.Extensions.MsgPack/StackExchange.Redis.Extensions.MsgPack.csproj
+++ b/src/serializers/StackExchange.Redis.Extensions.MsgPack/StackExchange.Redis.Extensions.MsgPack.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="MsgPack.Cli" Version="[1.0.1,2.0.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/serializers/StackExchange.Redis.Extensions.Newtonsoft/StackExchange.Redis.Extensions.Newtonsoft.csproj
+++ b/src/serializers/StackExchange.Redis.Extensions.Newtonsoft/StackExchange.Redis.Extensions.Newtonsoft.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="[13.0.4,14.0.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/serializers/StackExchange.Redis.Extensions.Protobuf/StackExchange.Redis.Extensions.Protobuf.csproj
+++ b/src/serializers/StackExchange.Redis.Extensions.Protobuf/StackExchange.Redis.Extensions.Protobuf.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="protobuf-net" Version="[3.2.56,4.0.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/serializers/StackExchange.Redis.Extensions.ServiceStack/StackExchange.Redis.Extensions.ServiceStack.csproj
+++ b/src/serializers/StackExchange.Redis.Extensions.ServiceStack/StackExchange.Redis.Extensions.ServiceStack.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="ServiceStack.Text" Version="[10.0.*,11.0.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/serializers/StackExchange.Redis.Extensions.System.Text.Json/StackExchange.Redis.Extensions.System.Text.Json.csproj
+++ b/src/serializers/StackExchange.Redis.Extensions.System.Text.Json/StackExchange.Redis.Extensions.System.Text.Json.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/serializers/StackExchange.Redis.Extensions.Utf8Json/StackExchange.Redis.Extensions.Utf8Json.csproj
+++ b/src/serializers/StackExchange.Redis.Extensions.Utf8Json/StackExchange.Redis.Extensions.Utf8Json.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Utf8Json" Version="[1.3.7,2.0.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/StackExchange.Redis.Extensions.Compression.Tests/StackExchange.Redis.Extensions.Compression.Tests.csproj
+++ b/tests/StackExchange.Redis.Extensions.Compression.Tests/StackExchange.Redis.Extensions.Compression.Tests.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/CacheClientTestBase.cs
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/CacheClientTestBase.cs
@@ -11,6 +11,8 @@ using Microsoft.Extensions.Logging;
 
 using NSubstitute;
 
+using StackExchange.Redis;
+
 using StackExchange.Redis.Extensions.Core.Abstractions;
 using StackExchange.Redis.Extensions.Core.Configuration;
 using StackExchange.Redis.Extensions.Core.Helpers;
@@ -1147,5 +1149,209 @@ public abstract partial class CacheClientTestBase : IDisposable
 
         var resultValue = await db.StringGetWithExpiryAsync(key);
         Assert.True(originalTime.Subtract(DateTime.UtcNow) < resultValue.Expiry!.Value);
+    }
+
+    [Fact]
+    public async Task SetCombineAsync_Union_Should_Return_All_Members_Async()
+    {
+        var key1 = Guid.NewGuid().ToString();
+        var key2 = Guid.NewGuid().ToString();
+
+        await Sut.GetDefaultDatabase().SetAddAsync(key1, "a");
+        await Sut.GetDefaultDatabase().SetAddAsync(key1, "b");
+        await Sut.GetDefaultDatabase().SetAddAsync(key2, "b");
+        await Sut.GetDefaultDatabase().SetAddAsync(key2, "c");
+
+        var result = await Sut.GetDefaultDatabase().SetCombineAsync<string>(SetOperation.Union, key1, key2);
+
+        Assert.Equal(3, result.Length);
+        Assert.Contains("a", result);
+        Assert.Contains("b", result);
+        Assert.Contains("c", result);
+    }
+
+    [Fact]
+    public async Task SetCombineAsync_Intersect_Should_Return_Common_Members_Async()
+    {
+        var key1 = Guid.NewGuid().ToString();
+        var key2 = Guid.NewGuid().ToString();
+
+        await Sut.GetDefaultDatabase().SetAddAsync(key1, "a");
+        await Sut.GetDefaultDatabase().SetAddAsync(key1, "b");
+        await Sut.GetDefaultDatabase().SetAddAsync(key2, "b");
+        await Sut.GetDefaultDatabase().SetAddAsync(key2, "c");
+
+        var result = await Sut.GetDefaultDatabase().SetCombineAsync<string>(SetOperation.Intersect, key1, key2);
+
+        Assert.Single(result);
+        Assert.Contains("b", result);
+    }
+
+    [Fact]
+    public async Task SetCombineAsync_Difference_Should_Return_Diff_Members_Async()
+    {
+        var key1 = Guid.NewGuid().ToString();
+        var key2 = Guid.NewGuid().ToString();
+
+        await Sut.GetDefaultDatabase().SetAddAsync(key1, "a");
+        await Sut.GetDefaultDatabase().SetAddAsync(key1, "b");
+        await Sut.GetDefaultDatabase().SetAddAsync(key2, "b");
+        await Sut.GetDefaultDatabase().SetAddAsync(key2, "c");
+
+        var result = await Sut.GetDefaultDatabase().SetCombineAsync<string>(SetOperation.Difference, key1, key2);
+
+        Assert.Single(result);
+        Assert.Contains("a", result);
+    }
+
+    [Fact]
+    public async Task SetCombineAsync_MultipleKeys_Should_Return_Correct_Union_Async()
+    {
+        var key1 = Guid.NewGuid().ToString();
+        var key2 = Guid.NewGuid().ToString();
+        var key3 = Guid.NewGuid().ToString();
+
+        await Sut.GetDefaultDatabase().SetAddAsync(key1, "a");
+        await Sut.GetDefaultDatabase().SetAddAsync(key2, "b");
+        await Sut.GetDefaultDatabase().SetAddAsync(key3, "c");
+
+        var result = await Sut.GetDefaultDatabase().SetCombineAsync<string>(SetOperation.Union, new[] { key1, key2, key3 });
+
+        Assert.Equal(3, result.Length);
+    }
+
+    [Fact]
+    public async Task SetCombineAndStoreAsync_Union_Should_Store_Result_Async()
+    {
+        var key1 = Guid.NewGuid().ToString();
+        var key2 = Guid.NewGuid().ToString();
+        var dest = Guid.NewGuid().ToString();
+
+        await Sut.GetDefaultDatabase().SetAddAsync(key1, "a");
+        await Sut.GetDefaultDatabase().SetAddAsync(key1, "b");
+        await Sut.GetDefaultDatabase().SetAddAsync(key2, "c");
+
+        var count = await Sut.GetDefaultDatabase().SetCombineAndStoreAsync(SetOperation.Union, dest, key1, key2);
+
+        Assert.Equal(3, count);
+        var members = await Sut.GetDefaultDatabase().SetMembersAsync<string>(dest);
+        Assert.Equal(3, members.Length);
+    }
+
+    [Fact]
+    public async Task SetCombineAndStoreAsync_MultipleKeys_Should_Store_Result_Async()
+    {
+        var key1 = Guid.NewGuid().ToString();
+        var key2 = Guid.NewGuid().ToString();
+        var key3 = Guid.NewGuid().ToString();
+        var dest = Guid.NewGuid().ToString();
+
+        await Sut.GetDefaultDatabase().SetAddAsync(key1, "a");
+        await Sut.GetDefaultDatabase().SetAddAsync(key2, "b");
+        await Sut.GetDefaultDatabase().SetAddAsync(key3, "c");
+
+        var count = await Sut.GetDefaultDatabase().SetCombineAndStoreAsync(SetOperation.Union, dest, new[] { key1, key2, key3 });
+
+        Assert.Equal(3, count);
+    }
+
+    [Fact]
+    public async Task StringIncrementAsync_Should_Increment_New_Key_From_Zero_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        var result = await Sut.GetDefaultDatabase().StringIncrementAsync(key);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task StringIncrementAsync_Should_Increment_Existing_Key_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        await Sut.GetDefaultDatabase().StringIncrementAsync(key, 5);
+        var result = await Sut.GetDefaultDatabase().StringIncrementAsync(key, 3);
+        Assert.Equal(8, result);
+    }
+
+    [Fact]
+    public async Task StringDecrementAsync_Should_Decrement_Below_Zero_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        var result = await Sut.GetDefaultDatabase().StringDecrementAsync(key, 5);
+        Assert.Equal(-5, result);
+    }
+
+    [Fact]
+    public async Task StringIncrementAsync_Double_Should_Increment_With_Fractional_Value_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        var result = await Sut.GetDefaultDatabase().StringIncrementAsync(key, 1.5);
+        Assert.Equal(1.5, result);
+        result = await Sut.GetDefaultDatabase().StringIncrementAsync(key, 2.3);
+        Assert.Equal(3.8, result, 1);
+    }
+
+    [Fact]
+    public async Task StringDecrementAsync_Double_Should_Decrement_With_Fractional_Value_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        await Sut.GetDefaultDatabase().StringIncrementAsync(key, 10.0);
+        var result = await Sut.GetDefaultDatabase().StringDecrementAsync(key, 3.5);
+        Assert.Equal(6.5, result, 1);
+    }
+
+    [Fact]
+    public async Task KeyRenameAsync_Should_Rename_Existing_Key_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        var newKey = Guid.NewGuid().ToString();
+        var value = new TestClass<string>("myKey", "my value");
+
+        await Sut.GetDefaultDatabase().AddAsync(key, value);
+        var result = await Sut.GetDefaultDatabase().KeyRenameAsync(key, newKey);
+
+        Assert.True(result);
+        Assert.False(await Sut.GetDefaultDatabase().ExistsAsync(key));
+        Assert.True(await Sut.GetDefaultDatabase().ExistsAsync(newKey));
+    }
+
+    [Fact]
+    public async Task KeyTypeAsync_String_Should_Return_String_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        await Sut.GetDefaultDatabase().AddAsync(key, "test");
+        var result = await Sut.GetDefaultDatabase().KeyTypeAsync(key);
+        Assert.Equal(RedisType.String, result);
+    }
+
+    [Fact]
+    public async Task KeyTypeAsync_Set_Should_Return_Set_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        await Sut.GetDefaultDatabase().SetAddAsync(key, "member1");
+        var result = await Sut.GetDefaultDatabase().KeyTypeAsync(key);
+        Assert.Equal(RedisType.Set, result);
+    }
+
+    [Fact]
+    public async Task KeyDumpAsync_And_KeyRestoreAsync_Should_Roundtrip_Async()
+    {
+        var sourceKey = Guid.NewGuid().ToString();
+        var destKey = Guid.NewGuid().ToString();
+
+        await Sut.GetDefaultDatabase().AddAsync(sourceKey, "test-value");
+        var dump = await Sut.GetDefaultDatabase().KeyDumpAsync(sourceKey);
+
+        Assert.NotNull(dump);
+
+        await Sut.GetDefaultDatabase().KeyRestoreAsync(destKey, dump!);
+        Assert.True(await Sut.GetDefaultDatabase().ExistsAsync(destKey));
+    }
+
+    [Fact]
+    public async Task KeyDumpAsync_NonExisting_Key_Should_Return_Null_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        var result = await Sut.GetDefaultDatabase().KeyDumpAsync(key);
+        Assert.Null(result);
     }
 }

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/KeyedDiTests.cs
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/KeyedDiTests.cs
@@ -86,4 +86,44 @@ public class KeyedDiTests
 
         Assert.Null(client);
     }
+
+    [Fact]
+    public void Should_Resolve_Default_Services_Alongside_Keyed()
+    {
+        var config = RedisConfigurationForTest.CreateBasicConfig();
+        config.Name = "test-redis";
+        config.IsDefault = true;
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddStackExchangeRedisExtensions<SystemTextJsonSerializer>(config);
+
+        using var sp = services.BuildServiceProvider();
+
+        var defaultClient = sp.GetService<IRedisClient>();
+        var keyedClient = sp.GetKeyedService<IRedisClient>("test-redis");
+
+        Assert.NotNull(defaultClient);
+        Assert.NotNull(keyedClient);
+    }
+
+    [Fact]
+    public void Should_Skip_Keyed_Registration_When_Name_Is_Empty()
+    {
+        var config = RedisConfigurationForTest.CreateBasicConfig();
+        config.Name = null;
+        config.IsDefault = true;
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddStackExchangeRedisExtensions<SystemTextJsonSerializer>(config);
+
+        using var sp = services.BuildServiceProvider();
+
+        var defaultClient = sp.GetService<IRedisClient>();
+        Assert.NotNull(defaultClient);
+
+        var keyedClient = sp.GetKeyedService<IRedisClient>("");
+        Assert.Null(keyedClient);
+    }
 }

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/KeyedDiTests.cs
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/KeyedDiTests.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+using StackExchange.Redis.Extensions.Core.Abstractions;
+using StackExchange.Redis.Extensions.Core.Configuration;
+using StackExchange.Redis.Extensions.Core.Tests.Helpers;
+using StackExchange.Redis.Extensions.System.Text.Json;
+
+using Xunit;
+
+namespace StackExchange.Redis.Extensions.Core.Tests;
+
+[Collection("Redis")]
+public class KeyedDiTests
+{
+    [Fact]
+    public void Should_Resolve_Keyed_RedisClient_By_Name()
+    {
+        var config = RedisConfigurationForTest.CreateBasicConfig();
+        config.Name = "test-redis";
+        config.IsDefault = true;
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddStackExchangeRedisExtensions<SystemTextJsonSerializer>(config);
+
+        using var sp = services.BuildServiceProvider();
+        var client = sp.GetKeyedService<IRedisClient>("test-redis");
+
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public void Should_Resolve_Keyed_RedisDatabase_By_Name()
+    {
+        var config = RedisConfigurationForTest.CreateBasicConfig();
+        config.Name = "test-redis";
+        config.IsDefault = true;
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddStackExchangeRedisExtensions<SystemTextJsonSerializer>(config);
+
+        using var sp = services.BuildServiceProvider();
+        var database = sp.GetKeyedService<IRedisDatabase>("test-redis");
+
+        Assert.NotNull(database);
+    }
+
+    [Fact]
+    public void Should_Resolve_Multiple_Keyed_Clients()
+    {
+        var config1 = RedisConfigurationForTest.CreateBasicConfig();
+        config1.Name = "cache";
+        config1.IsDefault = true;
+
+        var config2 = RedisConfigurationForTest.CreateBasicConfig();
+        config2.Name = "session";
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddStackExchangeRedisExtensions<SystemTextJsonSerializer>(new[] { config1, config2 });
+
+        using var sp = services.BuildServiceProvider();
+        var cacheClient = sp.GetKeyedService<IRedisClient>("cache");
+        var sessionClient = sp.GetKeyedService<IRedisClient>("session");
+
+        Assert.NotNull(cacheClient);
+        Assert.NotNull(sessionClient);
+    }
+
+    [Fact]
+    public void Should_Not_Resolve_Keyed_Client_With_Unknown_Name()
+    {
+        var config = RedisConfigurationForTest.CreateBasicConfig();
+        config.Name = "test-redis";
+        config.IsDefault = true;
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddStackExchangeRedisExtensions<SystemTextJsonSerializer>(config);
+
+        using var sp = services.BuildServiceProvider();
+        var client = sp.GetKeyedService<IRedisClient>("unknown");
+
+        Assert.Null(client);
+    }
+}

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/RedisDistributedCacheTests.cs
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/RedisDistributedCacheTests.cs
@@ -146,4 +146,68 @@ public sealed class RedisDistributedCacheTests : IDisposable
         Assert.NotNull(result);
         Assert.Equal(value, result);
     }
+
+    [Fact]
+    public async Task SetAsync_With_Both_Absolute_And_Sliding_Should_Use_Shorter_TTL_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        var value = Encoding.UTF8.GetBytes("test");
+
+        await sut.SetAsync(key, value, new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(60),
+            SlidingExpiration = TimeSpan.FromSeconds(10),
+        });
+
+        var ttl = await prefixedDb.KeyTimeToLiveAsync(key);
+        Assert.NotNull(ttl);
+        Assert.True(ttl!.Value.TotalSeconds <= 11, $"TTL should be ~10s (sliding wins), was {ttl.Value.TotalSeconds}s");
+        Assert.True(ttl.Value.TotalSeconds > 0);
+    }
+
+    [Fact]
+    public async Task SetAsync_With_Absolute_Shorter_Than_Sliding_Should_Use_Absolute_TTL_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        var value = Encoding.UTF8.GetBytes("test");
+
+        await sut.SetAsync(key, value, new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(5),
+            SlidingExpiration = TimeSpan.FromSeconds(30),
+        });
+
+        var ttl = await prefixedDb.KeyTimeToLiveAsync(key);
+        Assert.NotNull(ttl);
+        Assert.True(ttl!.Value.TotalSeconds <= 6, $"TTL should be ~5s (absolute wins), was {ttl.Value.TotalSeconds}s");
+        Assert.True(ttl.Value.TotalSeconds > 0);
+    }
+
+    [Fact]
+    public async Task SetAsync_With_AbsoluteExpiration_DateTimeOffset_Should_Set_TTL_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        var value = Encoding.UTF8.GetBytes("test");
+
+        await sut.SetAsync(key, value, new DistributedCacheEntryOptions
+        {
+            AbsoluteExpiration = DateTimeOffset.UtcNow.AddSeconds(30),
+        });
+
+        var ttl = await prefixedDb.KeyTimeToLiveAsync(key);
+        Assert.NotNull(ttl);
+        Assert.True(ttl!.Value.TotalSeconds > 0 && ttl.Value.TotalSeconds <= 30);
+    }
+
+    [Fact]
+    public void Set_With_Past_AbsoluteExpiration_Should_Throw()
+    {
+        var key = Guid.NewGuid().ToString();
+        var value = Encoding.UTF8.GetBytes("test");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => sut.Set(key, value, new DistributedCacheEntryOptions
+        {
+            AbsoluteExpiration = DateTimeOffset.UtcNow.AddSeconds(-10),
+        }));
+    }
 }

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/RedisDistributedCacheTests.cs
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/RedisDistributedCacheTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Caching.Distributed;
+
+using StackExchange.Redis.Extensions.AspNetCore.Caching;
+using StackExchange.Redis.Extensions.Core.Implementations;
+using StackExchange.Redis.Extensions.Core.Tests.Helpers;
+using StackExchange.Redis.Extensions.System.Text.Json;
+
+using Xunit;
+
+namespace StackExchange.Redis.Extensions.Core.Tests;
+
+[Collection("Redis")]
+public sealed class RedisDistributedCacheTests : IDisposable
+{
+    private readonly RedisConnectionPoolManager connectionPoolManager;
+    private readonly RedisDistributedCache sut;
+    private readonly IDatabase prefixedDb;
+    private readonly IDatabase rawDb;
+
+    public RedisDistributedCacheTests()
+    {
+        var config = RedisConfigurationForTest.CreateBasicConfig();
+        connectionPoolManager = new RedisConnectionPoolManager(config);
+        var serializer = new SystemTextJsonSerializer(new JsonSerializerOptions());
+        var redisClient = new RedisClient(connectionPoolManager, serializer, config);
+        var redisDatabase = redisClient.GetDefaultDatabase();
+        prefixedDb = redisDatabase.Database;
+        rawDb = connectionPoolManager.GetConnection().GetDatabase(config.Database);
+        sut = new RedisDistributedCache(redisDatabase);
+    }
+
+    public void Dispose()
+    {
+        rawDb.Execute("FLUSHDB");
+        connectionPoolManager.Dispose();
+    }
+
+    [Fact]
+    public async Task SetAsync_And_GetAsync_Should_Roundtrip_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        var value = Encoding.UTF8.GetBytes("hello world");
+
+        await sut.SetAsync(key, value, new DistributedCacheEntryOptions());
+        var result = await sut.GetAsync(key);
+
+        Assert.NotNull(result);
+        Assert.Equal(value, result);
+    }
+
+    [Fact]
+    public async Task GetAsync_NonExistent_Key_Should_Return_Null_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        var result = await sut.GetAsync(key);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task RemoveAsync_Should_Delete_Key_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        var value = Encoding.UTF8.GetBytes("test");
+
+        await sut.SetAsync(key, value, new DistributedCacheEntryOptions());
+        await sut.RemoveAsync(key);
+
+        var result = await sut.GetAsync(key);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task SetAsync_With_AbsoluteExpiration_Should_Set_TTL_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        var value = Encoding.UTF8.GetBytes("test");
+
+        await sut.SetAsync(key, value, new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(30),
+        });
+
+        var ttl = await prefixedDb.KeyTimeToLiveAsync(key);
+        Assert.NotNull(ttl);
+        Assert.True(ttl!.Value.TotalSeconds > 0 && ttl.Value.TotalSeconds <= 30);
+    }
+
+    [Fact]
+    public async Task SetAsync_With_SlidingExpiration_Should_Set_TTL_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        var value = Encoding.UTF8.GetBytes("test");
+
+        await sut.SetAsync(key, value, new DistributedCacheEntryOptions
+        {
+            SlidingExpiration = TimeSpan.FromSeconds(30),
+        });
+
+        var ttl = await prefixedDb.KeyTimeToLiveAsync(key);
+        Assert.NotNull(ttl);
+        Assert.True(ttl!.Value.TotalSeconds > 0 && ttl.Value.TotalSeconds <= 30);
+    }
+
+    [Fact]
+    public async Task GetAsync_With_SlidingExpiration_Should_Refresh_TTL_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        var value = Encoding.UTF8.GetBytes("test");
+
+        await sut.SetAsync(key, value, new DistributedCacheEntryOptions
+        {
+            SlidingExpiration = TimeSpan.FromSeconds(30),
+        });
+
+        await Task.Delay(2000);
+        await sut.GetAsync(key);
+
+        var ttl = await prefixedDb.KeyTimeToLiveAsync(key);
+        Assert.NotNull(ttl);
+        Assert.True(ttl!.Value.TotalSeconds > 28);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_NonExistent_Key_Should_Not_Throw_Async()
+    {
+        var key = Guid.NewGuid().ToString();
+        await sut.RefreshAsync(key);
+    }
+
+    [Fact]
+    public void Set_And_Get_Should_Roundtrip()
+    {
+        var key = Guid.NewGuid().ToString();
+        var value = Encoding.UTF8.GetBytes("sync test");
+
+        sut.Set(key, value, new DistributedCacheEntryOptions());
+        var result = sut.Get(key);
+
+        Assert.NotNull(result);
+        Assert.Equal(value, result);
+    }
+}

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/RedisHealthCheckTests.cs
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/RedisHealthCheckTests.cs
@@ -102,4 +102,160 @@ public class RedisHealthCheckTests
 
         Assert.Equal(HealthStatus.Unhealthy, result.Status);
     }
+
+    [Fact]
+    public async Task Should_Return_Unhealthy_When_Ping_Throws_RedisException_Async()
+    {
+        var poolManager = Substitute.For<IRedisConnectionPoolManager>();
+        poolManager.GetConnectionInformation().Returns(new ConnectionPoolInformation
+        {
+            ActiveConnections = 5,
+            InvalidConnections = 0,
+            RequiredPoolSize = 5,
+        });
+
+        var database = Substitute.For<IRedisDatabase>();
+        var redisDb = Substitute.For<IDatabase>();
+        redisDb.PingAsync(Arg.Any<CommandFlags>()).Returns<global::System.TimeSpan>(_ => throw new RedisException("test error"));
+        database.Database.Returns(redisDb);
+
+        var client = Substitute.For<IRedisClient>();
+        client.Name.Returns("test");
+        client.ConnectionPoolManager.Returns(poolManager);
+        client.GetDefaultDatabase().Returns(database);
+
+        var factory = Substitute.For<IRedisClientFactory>();
+        factory.GetAllClients().Returns([client]);
+
+        var healthCheck = new RedisHealthCheck(factory);
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Contains("PING failed", result.Description, global::System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Should_Return_Unhealthy_When_Ping_Throws_RedisTimeoutException_Async()
+    {
+        var poolManager = Substitute.For<IRedisConnectionPoolManager>();
+        poolManager.GetConnectionInformation().Returns(new ConnectionPoolInformation
+        {
+            ActiveConnections = 5,
+            InvalidConnections = 0,
+            RequiredPoolSize = 5,
+        });
+
+        var database = Substitute.For<IRedisDatabase>();
+        var redisDb = Substitute.For<IDatabase>();
+        redisDb.PingAsync(Arg.Any<CommandFlags>()).Returns<global::System.TimeSpan>(_ => throw new RedisTimeoutException("timeout", CommandStatus.Unknown));
+        database.Database.Returns(redisDb);
+
+        var client = Substitute.For<IRedisClient>();
+        client.Name.Returns("test");
+        client.ConnectionPoolManager.Returns(poolManager);
+        client.GetDefaultDatabase().Returns(database);
+
+        var factory = Substitute.For<IRedisClientFactory>();
+        factory.GetAllClients().Returns([client]);
+
+        var healthCheck = new RedisHealthCheck(factory);
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Contains("timed out", result.Description, global::System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Should_Return_Unhealthy_When_Ping_Throws_RedisConnectionException_Async()
+    {
+        var poolManager = Substitute.For<IRedisConnectionPoolManager>();
+        poolManager.GetConnectionInformation().Returns(new ConnectionPoolInformation
+        {
+            ActiveConnections = 5,
+            InvalidConnections = 0,
+            RequiredPoolSize = 5,
+        });
+
+        var database = Substitute.For<IRedisDatabase>();
+        var redisDb = Substitute.For<IDatabase>();
+        redisDb.PingAsync(Arg.Any<CommandFlags>()).Returns<global::System.TimeSpan>(_ => throw new RedisConnectionException(ConnectionFailureType.UnableToConnect, "connection lost"));
+        database.Database.Returns(redisDb);
+
+        var client = Substitute.For<IRedisClient>();
+        client.Name.Returns("test");
+        client.ConnectionPoolManager.Returns(poolManager);
+        client.GetDefaultDatabase().Returns(database);
+
+        var factory = Substitute.For<IRedisClientFactory>();
+        factory.GetAllClients().Returns([client]);
+
+        var healthCheck = new RedisHealthCheck(factory);
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Contains("connection error", result.Description, global::System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Should_Return_Unhealthy_When_No_Clients_Configured_Async()
+    {
+        var factory = Substitute.For<IRedisClientFactory>();
+        factory.GetAllClients().Returns(new List<IRedisClient>());
+
+        var healthCheck = new RedisHealthCheck(factory);
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Contains("No Redis clients", result.Description, global::System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Should_Return_Degraded_With_Multiple_Clients_When_One_Has_Invalid_Connections_Async()
+    {
+        var healthyPool = Substitute.For<IRedisConnectionPoolManager>();
+        healthyPool.GetConnectionInformation().Returns(new ConnectionPoolInformation
+        {
+            ActiveConnections = 5,
+            InvalidConnections = 0,
+            RequiredPoolSize = 5,
+        });
+
+        var degradedPool = Substitute.For<IRedisConnectionPoolManager>();
+        degradedPool.GetConnectionInformation().Returns(new ConnectionPoolInformation
+        {
+            ActiveConnections = 3,
+            InvalidConnections = 2,
+            RequiredPoolSize = 5,
+        });
+
+        var db1 = Substitute.For<IRedisDatabase>();
+        var redisDb1 = Substitute.For<IDatabase>();
+        redisDb1.PingAsync(Arg.Any<CommandFlags>()).Returns(global::System.TimeSpan.FromMilliseconds(1));
+        db1.Database.Returns(redisDb1);
+
+        var db2 = Substitute.For<IRedisDatabase>();
+        var redisDb2 = Substitute.For<IDatabase>();
+        redisDb2.PingAsync(Arg.Any<CommandFlags>()).Returns(global::System.TimeSpan.FromMilliseconds(2));
+        db2.Database.Returns(redisDb2);
+
+        var client1 = Substitute.For<IRedisClient>();
+        client1.Name.Returns("cache");
+        client1.ConnectionPoolManager.Returns(healthyPool);
+        client1.GetDefaultDatabase().Returns(db1);
+
+        var client2 = Substitute.For<IRedisClient>();
+        client2.Name.Returns("session");
+        client2.ConnectionPoolManager.Returns(degradedPool);
+        client2.GetDefaultDatabase().Returns(db2);
+
+        var factory = Substitute.For<IRedisClientFactory>();
+        factory.GetAllClients().Returns([client1, client2]);
+
+        var healthCheck = new RedisHealthCheck(factory);
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.True(result.Data.ContainsKey("cache:ping_ms"));
+        Assert.True(result.Data.ContainsKey("session:ping_ms"));
+    }
 }

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/RedisHealthCheckTests.cs
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/RedisHealthCheckTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+using NSubstitute;
+
+using StackExchange.Redis.Extensions.AspNetCore.HealthChecks;
+using StackExchange.Redis.Extensions.Core.Abstractions;
+using StackExchange.Redis.Extensions.Core.Models;
+
+using Xunit;
+
+namespace StackExchange.Redis.Extensions.Core.Tests;
+
+[Collection("Redis")]
+public class RedisHealthCheckTests
+{
+    [Fact]
+    public async Task Should_Return_Healthy_When_All_Connections_Active_Async()
+    {
+        var poolManager = Substitute.For<IRedisConnectionPoolManager>();
+        poolManager.GetConnectionInformation().Returns(new ConnectionPoolInformation
+        {
+            ActiveConnections = 5,
+            InvalidConnections = 0,
+            RequiredPoolSize = 5,
+        });
+
+        var database = Substitute.For<IRedisDatabase>();
+        var multiplexer = Substitute.For<IConnectionMultiplexer>();
+        var redisDb = Substitute.For<IDatabase>();
+        redisDb.PingAsync(Arg.Any<CommandFlags>()).Returns(global::System.TimeSpan.FromMilliseconds(1));
+        database.Database.Returns(redisDb);
+
+        var client = Substitute.For<IRedisClient>();
+        client.Name.Returns("test");
+        client.ConnectionPoolManager.Returns(poolManager);
+
+        var factory = Substitute.For<IRedisClientFactory>();
+        factory.GetAllClients().Returns([client]);
+        factory.GetDefaultRedisDatabase().Returns(database);
+
+        var healthCheck = new RedisHealthCheck(factory);
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
+    public async Task Should_Return_Degraded_When_Some_Connections_Invalid_Async()
+    {
+        var poolManager = Substitute.For<IRedisConnectionPoolManager>();
+        poolManager.GetConnectionInformation().Returns(new ConnectionPoolInformation
+        {
+            ActiveConnections = 3,
+            InvalidConnections = 2,
+            RequiredPoolSize = 5,
+        });
+
+        var database = Substitute.For<IRedisDatabase>();
+        var redisDb = Substitute.For<IDatabase>();
+        redisDb.PingAsync(Arg.Any<CommandFlags>()).Returns(global::System.TimeSpan.FromMilliseconds(1));
+        database.Database.Returns(redisDb);
+
+        var client = Substitute.For<IRedisClient>();
+        client.Name.Returns("test");
+        client.ConnectionPoolManager.Returns(poolManager);
+
+        var factory = Substitute.For<IRedisClientFactory>();
+        factory.GetAllClients().Returns([client]);
+        factory.GetDefaultRedisDatabase().Returns(database);
+
+        var healthCheck = new RedisHealthCheck(factory);
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+    }
+
+    [Fact]
+    public async Task Should_Return_Unhealthy_When_All_Connections_Invalid_Async()
+    {
+        var poolManager = Substitute.For<IRedisConnectionPoolManager>();
+        poolManager.GetConnectionInformation().Returns(new ConnectionPoolInformation
+        {
+            ActiveConnections = 0,
+            InvalidConnections = 5,
+            RequiredPoolSize = 5,
+        });
+
+        var client = Substitute.For<IRedisClient>();
+        client.Name.Returns("test");
+        client.ConnectionPoolManager.Returns(poolManager);
+
+        var factory = Substitute.For<IRedisClientFactory>();
+        factory.GetAllClients().Returns([client]);
+
+        var healthCheck = new RedisHealthCheck(factory);
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+    }
+}

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/StackExchange.Redis.Extensions.Core.Tests.csproj
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/StackExchange.Redis.Extensions.Core.Tests.csproj
@@ -25,6 +25,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\..\src\aspnet\StackExchange.Redis.Extensions.AspNetCore\StackExchange.Redis.Extensions.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\core\StackExchange.Redis.Extensions.Core\StackExchange.Redis.Extensions.Core.csproj" />
     <ProjectReference Include="..\..\src\serializers\StackExchange.Redis.Extensions.MsgPack\StackExchange.Redis.Extensions.MsgPack.csproj" />
     <ProjectReference Include="..\..\src\serializers\StackExchange.Redis.Extensions.Newtonsoft\StackExchange.Redis.Extensions.Newtonsoft.csproj" />

--- a/tests/StackExchange.Redis.Extensions.Core.Tests/StackExchange.Redis.Extensions.Core.Tests.csproj
+++ b/tests/StackExchange.Redis.Extensions.Core.Tests/StackExchange.Redis.Extensions.Core.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Neovolve.Logging.Xunit" Version="6.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -18,7 +18,7 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.categories" Version="3.0.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

Implements all 6 issues in the [v12.5 milestone](https://github.com/imperugo/StackExchange.Redis.Extensions/milestone/5), closing the "Core API Gaps" release:

- **#632 — IDistributedCache adapter**: `RedisDistributedCache` with Hash-based storage (`data`/`absexp`/`sldexp` fields), sliding expiration refresh on Get, and Microsoft.Extensions.Caching.StackExchangeRedis-compatible schema. Registered via `services.AddRedisDistributedCache()`.
- **#633 — Health Check**: `RedisHealthCheck` iterates all `IRedisClientFactory` clients, checks pool active/invalid connections, and PINGs the default database. Returns Healthy/Degraded/Unhealthy. Registered via `builder.AddRedisExtensionsHealthCheck()`.
- **#634 — StringIncrement/Decrement**: 4 overloads (`long` with default=1, `double` without default) delegating directly to SE.Redis.
- **#635 — Set Combine**: `SetCombineAsync<T>` (2-key and multi-key) with deserialization, plus `SetCombineAndStoreAsync` for server-side storage.
- **#636 — Key Management**: `KeyRenameAsync`, `KeyTypeAsync`, `KeyDumpAsync`, `KeyRestoreAsync` — thin wrappers over SE.Redis key operations.
- **#654 — Keyed DI Services**: Named `IRedisClient` and `IRedisDatabase` registered as keyed singletons when `RedisConfiguration.Name` is set. Supports `[FromKeyedServices("name")]` in .NET 8+.

Version bumped from 12.2.0 to 12.5.0.

### Documentation

- Updated README with usage examples for all 6 features
- Added `doc/health-check.md` — setup, status conditions, configuration
- Added `doc/distributed-cache.md` — setup, expiration behavior, storage format, key prefix details
- Updated `doc/multipleServers.md` — added Keyed DI Services with `[FromKeyedServices]` examples
- Updated `doc/asp.net-core/README.md` — added Health Check and IDistributedCache setup sections

## Test plan

- [x] 1125 tests passing on net10.0 (0 failures)
- [x] 1098 tests passing on net9.0 (1 pre-existing flaky timing test `Massive_Add_With_Expiring`)
- [ ] net8.0 — CI will validate (runtime not installed locally)
- [x] New tests: 16 CacheClientTestBase (Wave 1), 3 RedisHealthCheckTests, 8 RedisDistributedCacheTests, 4 KeyedDiTests = 31 new tests
- [x] Build: 0 errors, 0 warnings across all TFMs