### PR TITLE
Memory and CPU optimizations across pool, core, serializers, and compressors (v13.0.1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <!-- General information -->
     <PropertyGroup>
         <Authors>Ugo Lattanzi</Authors>
-        <VersionPrefix>13.0.0</VersionPrefix>
+        <VersionPrefix>13.0.1</VersionPrefix>
         <!--
         <VersionSuffix>pre</VersionSuffix>
         -->
@@ -50,6 +50,20 @@ Features:
 Serializer packages (pick one): System.Text.Json, Newtonsoft, MemoryPack, MsgPack, Protobuf, ServiceStack, Utf8Json.
         </Description>
         <PackageReleaseNotes>
+v13.0.1:
+- Performance: connection pool selection no longer allocates multiple ServerCounters snapshots per operation (LeastLoaded) and uses a true lock-free round-robin instead of a cryptographic RNG (RoundRobin)
+- Performance: RedisDatabase instances are cached per database number instead of being allocated on every Db0..Db16 access
+- Performance: HashGetAsync multi-key now issues a single HMGET instead of N parallel HGET round-trips
+- Performance: UpdateExpiryAsync no longer issues a redundant EXISTS before EXPIRE (half the round-trips)
+- Performance: AddAllAsync builds its payload without LINQ intermediate materializations
+- Performance: eager materialization of previously lazy IEnumerable results (SetPopAsync, SortedSetRangeByScoreAsync, HashKeysAsync, SearchKeysAsync) — no more re-deserialization on repeated enumeration
+- Performance: serializers (Newtonsoft, ServiceStack, MsgPack, Protobuf) no longer materialize intermediate UTF-16 strings or wrapping MemoryStreams
+- Performance: compressors use pooled buffers (Snappier, Brotli, ZstdSharp) and reused Zstd contexts; Snappier.Decompress no longer duplicates the output array
+- Performance: IDistributedCache adapter uses cached field arrays and batches HSET+EXPIRE in a single network write
+- Fixed HashGetAllAsyncAtOneTimeAsync applying KeyPrefix to hash fields instead of the hash key, and removed a potential Lua injection through the hash key
+- Fixed Utf8JsonSerializer.Deserialize throwing on null input instead of returning default
+- Fixed ListGetFromRightAsync duplicated null check (dead code)
+
 v13.0.0:
 - Added HyperLogLog API: HyperLogLogAddAsync, HyperLogLogLengthAsync, HyperLogLogMergeAsync (#637)
 - Added Distributed Lock API: LockTakeAsync, LockReleaseAsync, LockExtendAsync, LockQueryAsync, LockAcquireAsync with IAsyncDisposable auto-release (#638)

--- a/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/Caching/RedisDistributedCache.cs
+++ b/src/aspnet/StackExchange.Redis.Extensions.AspNetCore/Caching/RedisDistributedCache.cs
@@ -22,6 +22,11 @@ internal sealed class RedisDistributedCache : IDistributedCache
     private static readonly RedisValue AbsoluteExpirationField = "absexp";
     private static readonly RedisValue SlidingExpirationField = "sldexp";
 
+    // Cached field arrays: a collection expression at the call-site would allocate a new array on every Get/Refresh.
+    // SE.Redis never mutates the array (same pattern used by Microsoft.Extensions.Caching.StackExchangeRedis).
+    private static readonly RedisValue[] AllFields = [DataField, AbsoluteExpirationField, SlidingExpirationField];
+    private static readonly RedisValue[] MetadataFields = [AbsoluteExpirationField, SlidingExpirationField];
+
     private readonly IDatabase db;
 
     /// <summary>
@@ -110,12 +115,22 @@ internal sealed class RedisDistributedCache : IDistributedCache
             new(SlidingExpirationField, slidingTicks),
         };
 
-        await db.HashSetAsync(key, fields).ConfigureAwait(false);
-
         var expiry = GetExpirationTimeout(absoluteExpiration, options.SlidingExpiration);
 
         if (expiry.HasValue)
-            await db.KeyExpireAsync(key, expiry.Value).ConfigureAwait(false);
+        {
+            // A batch flushes HSET + EXPIRE in a single network write instead of two sequential round-trips.
+            var batch = db.CreateBatch();
+            var setTask = batch.HashSetAsync(key, fields);
+            var expireTask = batch.KeyExpireAsync(key, expiry.Value);
+            batch.Execute();
+
+            await Task.WhenAll(setTask, expireTask).ConfigureAwait(false);
+        }
+        else
+        {
+            await db.HashSetAsync(key, fields).ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc/>
@@ -163,9 +178,9 @@ internal sealed class RedisDistributedCache : IDistributedCache
         RedisValue[] results;
 
         if (getData)
-            results = db.HashGet(key, [DataField, AbsoluteExpirationField, SlidingExpirationField]);
+            results = db.HashGet(key, AllFields);
         else
-            results = db.HashGet(key, [AbsoluteExpirationField, SlidingExpirationField]);
+            results = db.HashGet(key, MetadataFields);
 
         if (results[0].IsNull)
             return null;
@@ -181,9 +196,9 @@ internal sealed class RedisDistributedCache : IDistributedCache
         RedisValue[] results;
 
         if (getData)
-            results = await db.HashGetAsync(key, [DataField, AbsoluteExpirationField, SlidingExpirationField]).ConfigureAwait(false);
+            results = await db.HashGetAsync(key, AllFields).ConfigureAwait(false);
         else
-            results = await db.HashGetAsync(key, [AbsoluteExpirationField, SlidingExpirationField]).ConfigureAwait(false);
+            results = await db.HashGetAsync(key, MetadataFields).ConfigureAwait(false);
 
         if (results[0].IsNull)
             return null;

--- a/src/compressors/StackExchange.Redis.Extensions.Compression.Brotli/BrotliCompressor.cs
+++ b/src/compressors/StackExchange.Redis.Extensions.Compression.Brotli/BrotliCompressor.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System;
+using System.Buffers;
 using System.IO;
 using System.IO.Compression;
 
@@ -11,6 +13,8 @@ namespace StackExchange.Redis.Extensions.Core;
 /// </summary>
 public class BrotliCompressor : ICompressor
 {
+    private const int BrotliDefaultWindow = 22;
+
     private readonly CompressionLevel compressionLevel;
 
     /// <summary>
@@ -25,12 +29,22 @@ public class BrotliCompressor : ICompressor
     /// <inheritdoc/>
     public byte[] Compress(byte[] data)
     {
-        using var output = new MemoryStream();
+        // The one-shot encoder avoids the BrotliStream state machine and the MemoryStream growth copies:
+        // a single rented worst-case buffer plus the exact-size result array.
+        var maxLength = BrotliEncoder.GetMaxCompressedLength(data.Length);
+        var buffer = ArrayPool<byte>.Shared.Rent(maxLength);
 
-        using (var brotli = new BrotliStream(output, compressionLevel))
-            brotli.Write(data, 0, data.Length);
+        try
+        {
+            if (!BrotliEncoder.TryCompress(data, buffer, out var written, GetQuality(compressionLevel), BrotliDefaultWindow))
+                throw new InvalidOperationException("Brotli compression failed.");
 
-        return output.ToArray();
+            return buffer.AsSpan(0, written).ToArray();
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
     }
 
     /// <inheritdoc/>
@@ -38,10 +52,21 @@ public class BrotliCompressor : ICompressor
     {
         using var input = new MemoryStream(compressedData);
         using var brotli = new BrotliStream(input, CompressionMode.Decompress);
-        using var output = new MemoryStream();
+
+        // Pre-sized with a typical-ratio heuristic to avoid the growth copies of an empty MemoryStream.
+        using var output = new MemoryStream(compressedData.Length * 4);
 
         brotli.CopyTo(output);
 
         return output.ToArray();
     }
+
+    // Same CompressionLevel-to-quality mapping the runtime uses internally for BrotliStream.
+    private static int GetQuality(CompressionLevel level) => level switch
+    {
+        CompressionLevel.NoCompression => 0,
+        CompressionLevel.Fastest => 1,
+        CompressionLevel.SmallestSize => 11,
+        _ => 4,
+    };
 }

--- a/src/compressors/StackExchange.Redis.Extensions.Compression.GZip/GZipCompressor.cs
+++ b/src/compressors/StackExchange.Redis.Extensions.Compression.GZip/GZipCompressor.cs
@@ -25,7 +25,8 @@ public class GZipCompressor : ICompressor
     /// <inheritdoc/>
     public byte[] Compress(byte[] data)
     {
-        using var output = new MemoryStream();
+        // Pre-sized to avoid the growth copies of an empty MemoryStream (the +64 covers the GZip header on tiny payloads).
+        using var output = new MemoryStream((data.Length / 2) + 64);
 
         using (var gzip = new GZipStream(output, compressionLevel))
             gzip.Write(data, 0, data.Length);
@@ -38,7 +39,9 @@ public class GZipCompressor : ICompressor
     {
         using var input = new MemoryStream(compressedData);
         using var gzip = new GZipStream(input, CompressionMode.Decompress);
-        using var output = new MemoryStream();
+
+        // Pre-sized with a typical-ratio heuristic to avoid the growth copies of an empty MemoryStream.
+        using var output = new MemoryStream(compressedData.Length * 3);
 
         gzip.CopyTo(output);
 

--- a/src/compressors/StackExchange.Redis.Extensions.Compression.Snappier/SnappierCompressor.cs
+++ b/src/compressors/StackExchange.Redis.Extensions.Compression.Snappier/SnappierCompressor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 
 using Snappier;
 
@@ -15,11 +16,20 @@ public class SnappierCompressor : ICompressor
     /// <inheritdoc/>
     public byte[] Compress(byte[] data)
     {
+        // The worst-case buffer (~1.17x input) is only transient: renting it avoids a heap (or LOH) allocation per call.
         var maxLength = Snappy.GetMaxCompressedLength(data.Length);
-        var buffer = new byte[maxLength];
-        var compressedLength = Snappy.Compress(data, buffer);
+        var buffer = ArrayPool<byte>.Shared.Rent(maxLength);
 
-        return buffer.AsSpan(0, compressedLength).ToArray();
+        try
+        {
+            var compressedLength = Snappy.Compress(data, buffer);
+
+            return buffer.AsSpan(0, compressedLength).ToArray();
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
     }
 
     /// <inheritdoc/>
@@ -29,6 +39,8 @@ public class SnappierCompressor : ICompressor
         var buffer = new byte[decompressedLength];
         var actualLength = Snappy.Decompress(compressedData, buffer);
 
-        return buffer.AsSpan(0, actualLength).ToArray();
+        // The header-declared length matches the actual output, so the buffer can be returned as-is
+        // instead of being copied a second time.
+        return actualLength == decompressedLength ? buffer : buffer.AsSpan(0, actualLength).ToArray();
     }
 }

--- a/src/compressors/StackExchange.Redis.Extensions.Compression.ZstdSharp/ZstdSharpCompressor.cs
+++ b/src/compressors/StackExchange.Redis.Extensions.Compression.ZstdSharp/ZstdSharpCompressor.cs
@@ -1,5 +1,9 @@
 // Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System;
+using System.Buffers;
+using System.Threading;
+
 using ZstdSharp;
 
 namespace StackExchange.Redis.Extensions.Core;
@@ -10,7 +14,10 @@ namespace StackExchange.Redis.Extensions.Core;
 /// </summary>
 public class ZstdSharpCompressor : ICompressor
 {
-    private readonly int compressionLevel;
+    // Zstd contexts are designed for reuse and are expensive to initialize, but they are not thread-safe:
+    // one context per thread replaces the previous new-context-per-call pattern.
+    private readonly ThreadLocal<Compressor> compressor;
+    private readonly ThreadLocal<Decompressor> decompressor = new(static () => new Decompressor());
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ZstdSharpCompressor"/> class.
@@ -18,22 +25,39 @@ public class ZstdSharpCompressor : ICompressor
     /// <param name="compressionLevel">The Zstd compression level (1-22). Defaults to 3 (fast).</param>
     public ZstdSharpCompressor(int compressionLevel = 3)
     {
-        this.compressionLevel = compressionLevel;
+        compressor = new(() => new Compressor(compressionLevel));
     }
 
     /// <inheritdoc/>
     public byte[] Compress(byte[] data)
     {
-        using var compressor = new Compressor(compressionLevel);
+        var bound = Compressor.GetCompressBound(data.Length);
+        var buffer = ArrayPool<byte>.Shared.Rent(bound);
 
-        return compressor.Wrap(data).ToArray();
+        try
+        {
+            var written = compressor.Value!.Wrap(data, buffer);
+
+            return buffer.AsSpan(0, written).ToArray();
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
     }
 
     /// <inheritdoc/>
     public byte[] Decompress(byte[] compressedData)
     {
-        using var decompressor = new Decompressor();
+        var size = Decompressor.GetDecompressedSize(compressedData);
 
-        return decompressor.Unwrap(compressedData).ToArray();
+        // Frames produced by Wrap always carry the content size; the fallback covers foreign frames without it.
+        if (size == 0 || size > int.MaxValue)
+            return decompressor.Value!.Unwrap(compressedData).ToArray();
+
+        var result = new byte[(int)size];
+        var written = decompressor.Value!.Unwrap(compressedData, result);
+
+        return written == result.Length ? result : result.AsSpan(0, written).ToArray();
     }
 }

--- a/src/core/StackExchange.Redis.Extensions.Core/Extensions/SpanExtensions.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Extensions/SpanExtensions.cs
@@ -48,17 +48,6 @@ internal static class SpanExtensions
         }
     }
 
-    public static bool Any<T>(this ReadOnlySpan<T> span, Predicate<T> condition)
-    {
-        for (var i = 0; i < span.Length; i++)
-        {
-            if (condition(span[i]))
-                return true;
-        }
-
-        return false;
-    }
-
     public static TResult[] ToFastArray<TSource, TResult>(this ReadOnlySpan<TSource> span, Func<TSource, TResult> action)
     {
         if (span.IsEmpty)

--- a/src/core/StackExchange.Redis.Extensions.Core/Extensions/ValueLengthExtensions.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Extensions/ValueLengthExtensions.cs
@@ -7,19 +7,23 @@ namespace StackExchange.Redis.Extensions.Core.Extensions;
 
 internal static class ValueLengthExtensions
 {
-    public static IEnumerable<KeyValuePair<string, byte[]>> OfValueInListSize<T>(this IEnumerable<Tuple<string, T>> items, ISerializer serializer, uint maxValueLength)
+    public static KeyValuePair<RedisKey, RedisValue>[] ToRedisEntries<T>(this Tuple<string, T>[] items, ISerializer serializer, uint maxValueLength)
     {
-        using var iterator = items.GetEnumerator();
+        var result = new KeyValuePair<RedisKey, RedisValue>[items.Length];
+        var count = 0;
 
-        while (iterator.MoveNext())
+        foreach (var item in items)
         {
-            if (iterator.Current != null)
-            {
-                yield return new(
-                    iterator.Current.Item1,
-                    iterator.Current.Item2.SerializeItem(serializer).CheckLength(maxValueLength, iterator.Current.Item1));
-            }
+            if (item == null)
+                continue;
+
+            result[count++] = new(item.Item1, item.Item2.SerializeItem(serializer).CheckLength(maxValueLength, item.Item1));
         }
+
+        if (count != result.Length)
+            Array.Resize(ref result, count);
+
+        return result;
     }
 
     public static byte[] OfValueSize<T>(this T? value, ISerializer serializer, uint maxValueLength, string key)
@@ -42,34 +46,5 @@ internal static class ValueLengthExtensions
             throw new ArgumentException("value cannot be longer than the MaxValueLength", paramName);
 
         return byteArray;
-    }
-
-    public static TSource MinBy<TSource, TKey>(
-        this IEnumerable<TSource> source,
-        Func<TSource, TKey> selector,
-        IComparer<TKey>? comparer = null)
-    {
-        comparer ??= Comparer<TKey>.Default;
-
-        using var sourceIterator = source.GetEnumerator();
-
-        if (!sourceIterator.MoveNext())
-            throw new InvalidOperationException("Sequence contains no elements");
-
-        var min = sourceIterator.Current;
-        var minKey = selector(min);
-
-        while (sourceIterator.MoveNext())
-        {
-            var candidate = sourceIterator.Current;
-            var candidateProjected = selector(candidate);
-            if (comparer.Compare(candidateProjected, minKey) < 0)
-            {
-                min = candidate;
-                minKey = candidateProjected;
-            }
-        }
-
-        return min;
     }
 }

--- a/src/core/StackExchange.Redis.Extensions.Core/Helpers/ExceptionThrowHelper.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Helpers/ExceptionThrowHelper.cs
@@ -1,15 +1,16 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-using StackExchange.Redis.Extensions.Core.Extensions;
-
 namespace StackExchange.Redis.Extensions.Core.Helpers;
 internal static class ExceptionThrowHelper
 {
     public static void ThrowIfExistsNullElement<T>(ReadOnlySpan<T> argument, string paramName)
     {
-        if (argument.Any(x => x is null))
-            ThrowNullElementException(paramName);
+        foreach (var item in argument)
+        {
+            if (item is null)
+                ThrowNullElementException(paramName);
+        }
     }
 
     [DoesNotReturn]

--- a/src/core/StackExchange.Redis.Extensions.Core/Helpers/GenericsExtensions.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Helpers/GenericsExtensions.cs
@@ -1,36 +1,13 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+#if NET8_0_OR_GREATER
 using System.Runtime.InteropServices;
+#endif
 
 namespace StackExchange.Redis.Extensions.Core.Helpers;
 
 internal static class GenericsExtensions
 {
-    public static void FastIteration<TSource>(this ICollection<TSource>? request, Action<TSource, int> action)
-    {
-        if (request == null)
-            return;
-
-        if (request is TSource[] sourceArray)
-        {
-            ref var searchSpace = ref MemoryMarshal.GetReference(sourceArray.AsSpan());
-
-            for (var i = 0; i < sourceArray.Length; i++)
-            {
-                ref var r = ref Unsafe.Add(ref searchSpace, i);
-
-                action.Invoke(r, i);
-            }
-        }
-        else
-        {
-            var i = 0;
-            foreach (var r in request)
-                action.Invoke(r, i++);
-        }
-    }
-
     public static TResult[] ToFastArray<TSource, TResult>(this TSource[]? source, Func<TSource, TResult> action)
     {
         if (source is not { Length: > 0 })
@@ -48,16 +25,37 @@ internal static class GenericsExtensions
         if (source is null)
             return [];
 
+        if (source is TSource[] sourceArray)
+            return sourceArray.ToFastArray(action);
+
+#if NET8_0_OR_GREATER
+        // Iterating a List<T> through ICollection<T> would box its struct enumerator; the span avoids both
+        // the boxing and the per-item interface dispatch.
+        if (source is List<TSource> sourceList)
+        {
+            var span = CollectionsMarshal.AsSpan(sourceList);
+
+            if (span.Length == 0)
+                return [];
+
+            var listResult = new TResult[span.Length];
+            for (var i = 0; i < span.Length; i++)
+                listResult[i] = action.Invoke(span[i]);
+
+            return listResult;
+        }
+#endif
+
         var srcCnt = source.Count;
         if (srcCnt == 0)
             return [];
 
         var result = new TResult[srcCnt];
-        var i = 0;
+        var i2 = 0;
         foreach (var item in source)
         {
-            result[i] = action.Invoke(item);
-            i++;
+            result[i2] = action.Invoke(item);
+            i2++;
         }
 
         return result;

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisClient.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisClient.cs
@@ -1,5 +1,8 @@
 // Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System;
+using System.Threading;
+
 using Microsoft.Extensions.Logging;
 
 using StackExchange.Redis.Extensions.Core.Abstractions;
@@ -12,6 +15,11 @@ public class RedisClient : IRedisClient
 {
     private readonly RedisConfiguration redisConfiguration;
     private readonly ILogger<RedisDatabase>? databaseLogger;
+
+    // RedisDatabase is immutable and stateless (the pooled connection is resolved per operation),
+    // so instances can be cached per database number instead of being allocated on every Db0..Db16 access.
+    // The prefix is stored alongside because RedisConfiguration.KeyPrefix is mutable at runtime.
+    private readonly CachedDatabase?[] databaseCache = new CachedDatabase?[17];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RedisClient"/> class.
@@ -90,7 +98,25 @@ public class RedisClient : IRedisClient
         if (string.IsNullOrEmpty(keyPrefix))
             keyPrefix = redisConfiguration.KeyPrefix;
 
-        return new RedisDatabase(
+        if ((uint)dbNumber >= (uint)databaseCache.Length)
+            return CreateDatabase(dbNumber, keyPrefix);
+
+        var cached = Volatile.Read(ref databaseCache[dbNumber]);
+
+        if (cached != null && string.Equals(cached.KeyPrefix, keyPrefix, StringComparison.Ordinal))
+            return cached.Database;
+
+        var created = CreateDatabase(dbNumber, keyPrefix);
+
+        // A benign race may create an extra instance; that matches the previous allocate-per-call behavior.
+        Volatile.Write(ref databaseCache[dbNumber], new CachedDatabase(created, keyPrefix));
+
+        return created;
+    }
+
+    private RedisDatabase CreateDatabase(int dbNumber, string? keyPrefix)
+    {
+        return new(
             ConnectionPoolManager,
             Serializer,
             redisConfiguration.ServerEnumerationStrategy,
@@ -111,4 +137,11 @@ public class RedisClient : IRedisClient
 
     /// <inheritdoc/>
     public string Name => redisConfiguration.Name ?? IRedisClient.DefaultName;
+
+    private sealed class CachedDatabase(IRedisDatabase database, string? keyPrefix)
+    {
+        public IRedisDatabase Database { get; } = database;
+
+        public string? KeyPrefix { get; } = keyPrefix;
+    }
 }

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisConnectionPoolManager.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisConnectionPoolManager.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
@@ -24,10 +24,10 @@ namespace StackExchange.Redis.Extensions.Core.Implementations;
 /// <inheritdoc/>
 public sealed partial class RedisConnectionPoolManager : IRedisConnectionPoolManager
 {
-    private static readonly object @lock = new();
     private readonly IStateAwareConnection[] connections;
     private readonly RedisConfiguration redisConfiguration;
     private readonly ILogger<RedisConnectionPoolManager> logger;
+    private int roundRobinIndex = -1;
     private bool isDisposed;
 
     /// <summary>
@@ -41,14 +41,11 @@ public sealed partial class RedisConnectionPoolManager : IRedisConnectionPoolMan
         logger ??= redisConfiguration.LoggerFactory?.CreateLogger<RedisConnectionPoolManager>();
         this.logger = logger ?? NullLogger<RedisConnectionPoolManager>.Instance;
 
-        lock (@lock)
-        {
-            connections = new IStateAwareConnection[redisConfiguration.PoolSize];
+        connections = new IStateAwareConnection[redisConfiguration.PoolSize];
 
 #pragma warning disable VSTHRD002 // Synchronous wait is required here because constructors cannot be async
-            EmitConnectionsAsync().GetAwaiter().GetResult();
+        EmitConnectionsAsync().GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002
-        }
     }
 
     /// <inheritdoc/>
@@ -82,12 +79,8 @@ public sealed partial class RedisConnectionPoolManager : IRedisConnectionPoolMan
         switch (redisConfiguration.ConnectionSelectionStrategy)
         {
             case ConnectionSelectionStrategy.RoundRobin:
-                var nextIdx
-#if NET6_0_OR_GREATER
-                = RandomNumberGenerator.GetInt32(0, redisConfiguration.PoolSize);
-#else
-                = new Random().Next(0, redisConfiguration.PoolSize);
-#endif
+                // Casting to uint handles the int wraparound: the modulo stays valid across overflow.
+                var nextIdx = (int)((uint)Interlocked.Increment(ref roundRobinIndex) % (uint)connections.Length);
                 connection = connections[nextIdx];
 
                 if (!connection.IsConnected())
@@ -106,19 +99,40 @@ public sealed partial class RedisConnectionPoolManager : IRedisConnectionPoolMan
                 break;
 
             case ConnectionSelectionStrategy.LeastLoaded:
-                // Prefer connected connections; fall back to any if all are disconnected
+                // Prefer connected connections; fall back to any if all are disconnected.
+                // TotalOutstanding() allocates a ServerCounters snapshot in SE.Redis, so it must be called at most once per connection.
                 IStateAwareConnection? candidate = null;
+                var candidateOutstanding = long.MaxValue;
 
                 for (var i = 0; i < connections.Length; i++)
                 {
                     if (!connections[i].IsConnected())
                         continue;
 
-                    if (candidate == null || connections[i].TotalOutstanding() < candidate.TotalOutstanding())
+                    var outstanding = connections[i].TotalOutstanding();
+
+                    if (outstanding < candidateOutstanding)
+                    {
                         candidate = connections[i];
+                        candidateOutstanding = outstanding;
+                    }
                 }
 
-                connection = candidate ?? connections.MinBy(x => x.TotalOutstanding());
+                if (candidate == null)
+                {
+                    for (var i = 0; i < connections.Length; i++)
+                    {
+                        var outstanding = connections[i].TotalOutstanding();
+
+                        if (outstanding < candidateOutstanding)
+                        {
+                            candidate = connections[i];
+                            candidateOutstanding = outstanding;
+                        }
+                    }
+                }
+
+                connection = candidate!;
                 break;
 
             default:
@@ -128,7 +142,9 @@ public sealed partial class RedisConnectionPoolManager : IRedisConnectionPoolMan
         if (!connection.IsConnected())
             LogMessages.AllConnectionsDisconnected(logger, connection.Connection.GetHashCode());
 
-        LogMessages.ConnectionSelected(logger, connection.Connection.GetHashCode(), connection.TotalOutstanding());
+        // Guarded because TotalOutstanding() allocates: log arguments are evaluated at the call-site even when the level is disabled.
+        if (logger.IsEnabled(LogLevel.Debug))
+            LogMessages.ConnectionSelected(logger, connection.Connection.GetHashCode(), connection.TotalOutstanding());
 
         return connection.Connection;
     }

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.Hash.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.Hash.cs
@@ -3,8 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 using StackExchange.Redis.Extensions.Core.Helpers;
@@ -47,73 +45,42 @@ public partial class RedisDatabase
     /// <inheritdoc/>
     public async Task<IDictionary<string, T?>> HashGetAsync<T>(string hashKey, string[] keys, CommandFlags flag = CommandFlags.None)
     {
-#if NET6_0_OR_GREATER
-        var concurrent = new System.Collections.Concurrent.ConcurrentDictionary<string, T?>();
+        // A single HMGET replaces N parallel HGET round-trips.
+        var fields = keys.ToFastArray(key => (RedisValue)key);
 
-        await Parallel.ForEachAsync(keys, async (key, _) =>
-        {
-            var result = await HashGetAsync<T>(hashKey, key, flag);
-            concurrent.TryAdd(key, result);
-        })
-            .ConfigureAwait(false);
+        var values = await Database.HashGetAsync(hashKey, fields, flag).ConfigureAwait(false);
 
-        return concurrent;
-#else
-        var tasks = new Task<T?>[keys.Length];
+        var result = new Dictionary<string, T?>(keys.Length, StringComparer.Ordinal);
 
         for (var i = 0; i < keys.Length; i++)
-            tasks[i] = HashGetAsync<T>(hashKey, keys[i], flag);
-
-        await Task.WhenAll(tasks).ConfigureAwait(false);
-
-        var result = new Dictionary<string, T?>();
-
-        ref var searchSpace = ref MemoryMarshal.GetReference(tasks.AsSpan());
-
-        for (var i = 0; i < tasks.Length; i++)
         {
-            ref var task = ref Unsafe.Add(ref searchSpace, i);
-            result.Add(keys[i], task.Result);
+            var value = values[i];
+            result[keys[i]] = value.HasValue ? Serializer.Deserialize<T>(value) : default;
         }
 
         return result;
-#endif
     }
 
     /// <inheritdoc/>
     public async Task<IDictionary<string, T?>> HashGetAllAsyncAtOneTimeAsync<T>(string hashKey, string[] keys, CommandFlags flag = CommandFlags.None)
     {
-        var luascript = "local results = {};local insert = table.insert;local rcall = redis.call;for i=1,table.getn(KEYS) do  local value = rcall('HGET','" + hashKey + "', KEYS[i])  if value then insert(results, KEYS[i]) insert(results, value) end end; return results;";
+        // A single HMGET replaces the previous per-call Lua script. Going through HashGetAsync also means the
+        // KeyPrefix is applied to the hash key (the script embedded it unprefixed, and wrongly prefixed the
+        // hash fields passed as KEYS) and the hash key is no longer exposed to Lua injection.
+        var fields = keys.ToFastArray(key => (RedisValue)key);
 
-        var redisKeys = keys.ToFastArray(key => new RedisKey(key));
+        var values = await Database.HashGetAsync(hashKey, fields, flag).ConfigureAwait(false);
 
-        var data = await Database.ScriptEvaluateAsync(luascript, redisKeys, flags: flag).ConfigureAwait(false);
+        var dictionary = new Dictionary<string, T?>(keys.Length, StringComparer.Ordinal);
 
-        var dictionary = new Dictionary<string, T?>();
-
-        var redisValues = (RedisValue[]?)data;
-
-        ref var searchSpaceRedisValue = ref MemoryMarshal.GetReference(redisValues.AsSpan());
-
-        if (redisValues is not { Length: > 0 })
-            return dictionary;
-
-        for (var i = 0; i < redisValues.Length; i += 2)
+        for (var i = 0; i < keys.Length; i++)
         {
-            ref var key = ref Unsafe.Add(ref searchSpaceRedisValue, i);
+            var value = values[i];
 
-            if (!key.HasValue)
+            if (!value.HasValue)
                 continue;
 
-            var redisValue = redisValues[i + 1];
-
-            if (!redisValue.HasValue)
-                continue;
-
-#pragma warning disable CS8604 // Possible null reference argument.
-            var value = Serializer.Deserialize<T?>(redisValue);
-            dictionary.Add(key, value);
-#pragma warning restore CS8604 // Possible null reference argument.
+            dictionary.Add(keys[i], Serializer.Deserialize<T?>(value));
         }
 
         return dictionary;
@@ -144,7 +111,8 @@ public partial class RedisDatabase
     /// <inheritdoc/>
     public async Task<IEnumerable<string>> HashKeysAsync(string hashKey, CommandFlags flag = CommandFlags.None)
     {
-        return (await Database.HashKeysAsync(hashKey, flag).ConfigureAwait(false)).Select(x => x.ToString());
+        // Materialized eagerly: a lazy Select would re-allocate every string on each enumeration.
+        return (await Database.HashKeysAsync(hashKey, flag).ConfigureAwait(false)).ToFastArray(x => x.ToString());
     }
 
     /// <inheritdoc/>

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.List.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.List.cs
@@ -60,9 +60,6 @@ public partial class RedisDatabase
 
         var item = await Database.ListRightPopAsync(key, flag).ConfigureAwait(false);
 
-        if (item == RedisValue.Null)
-            return default;
-
         return item == RedisValue.Null
             ? default
             : Serializer.Deserialize<T>(item);

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.PubSub.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.PubSub.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 
 using StackExchange.Redis.Extensions.Core.Helpers;
@@ -35,17 +34,22 @@ public partial class RedisDatabase
 
         void Handler(RedisChannel redisChannel, RedisValue value)
         {
-            var task = Task.Run(async () =>
+            // Task.Run keeps user handlers off the SE.Redis callback thread; the try/catch replaces a
+            // ContinueWith continuation that was allocated per message even on the success path.
+            _ = Task.Run(async () =>
             {
-                var deserialized = Serializer.Deserialize<T>(value);
-                await handler(deserialized).ConfigureAwait(false);
+                try
+                {
+                    var deserialized = Serializer.Deserialize<T>(value);
+                    await handler(deserialized).ConfigureAwait(false);
+                }
+#pragma warning disable CA1031 // User handlers can throw anything; a failed message must never tear down the subscription.
+                catch (Exception ex)
+#pragma warning restore CA1031
+                {
+                    LogMessages.SubscriptionHandlerError(logger, ex, (string?)redisChannel ?? "unknown");
+                }
             });
-
-            task.ContinueWith(
-                t => LogMessages.SubscriptionHandlerError(logger, t.Exception, (string?)redisChannel ?? "unknown"),
-                CancellationToken.None,
-                TaskContinuationOptions.OnlyOnFaulted,
-                TaskScheduler.Default);
         }
     }
 
@@ -79,33 +83,34 @@ public partial class RedisDatabase
     }
 
     /// <inheritdoc/>
-    public async Task<bool> UpdateExpiryAsync(string key, DateTimeOffset expiresAt, CommandFlags flag = CommandFlags.None)
+    public Task<bool> UpdateExpiryAsync(string key, DateTimeOffset expiresAt, CommandFlags flag = CommandFlags.None)
     {
-        if (await Database.KeyExistsAsync(key).ConfigureAwait(false))
-            return await Database.KeyExpireAsync(key, expiresAt.UtcDateTime.Subtract(DateTime.UtcNow), flag).ConfigureAwait(false);
-
-        return false;
+        // EXPIRE already returns false on missing keys: the previous EXISTS pre-check doubled the round-trips
+        // without adding correctness (the two commands were not atomic anyway).
+        return Database.KeyExpireAsync(key, expiresAt.UtcDateTime.Subtract(DateTime.UtcNow), flag);
     }
 
     /// <inheritdoc/>
-    public async Task<bool> UpdateExpiryAsync(string key, TimeSpan expiresIn, CommandFlags flag = CommandFlags.None)
+    public Task<bool> UpdateExpiryAsync(string key, TimeSpan expiresIn, CommandFlags flag = CommandFlags.None)
     {
-        if (await Database.KeyExistsAsync(key).ConfigureAwait(false))
-            return await Database.KeyExpireAsync(key, expiresIn, flag).ConfigureAwait(false);
-
-        return false;
+        return Database.KeyExpireAsync(key, expiresIn, flag);
     }
 
     /// <inheritdoc/>
     public async Task<IDictionary<string, bool>> UpdateExpiryAllAsync(HashSet<string> keys, DateTimeOffset expiresAt, CommandFlags flag = CommandFlags.None)
     {
-        var tasks = keys.ToFastArray(key => UpdateExpiryAsync(key, expiresAt.UtcDateTime, flag));
+        // Computed once: the previous per-key computation re-read DateTime.UtcNow for every key, drifting the TTL.
+        var expiresIn = expiresAt.UtcDateTime.Subtract(DateTime.UtcNow);
+
+        var tasks = keys.ToFastArray(key => UpdateExpiryAsync(key, expiresIn, flag));
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
 
         var results = new Dictionary<string, bool>(keys.Count, StringComparer.Ordinal);
+        var i = 0;
 
-        keys.FastIteration((key, i) => results.Add(key, tasks[i].Result));
+        foreach (var key in keys)
+            results.Add(key, tasks[i++].Result);
 
         return results;
     }
@@ -118,8 +123,10 @@ public partial class RedisDatabase
         await Task.WhenAll(tasks).ConfigureAwait(false);
 
         var results = new Dictionary<string, bool>(keys.Count, StringComparer.Ordinal);
+        var i = 0;
 
-        keys.FastIteration((key, i) => results.Add(key, tasks[i].Result));
+        foreach (var key in keys)
+            results.Add(key, tasks[i++].Result);
 
         return results;
     }

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.Sort.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.Sort.cs
@@ -47,7 +47,8 @@ public partial class RedisDatabase
     {
         var result = await Database.SortedSetRangeByScoreAsync(key, start, stop, exclude, order, skip, take, flag).ConfigureAwait(false);
 
-        return result.Select(m => m == RedisValue.Null ? default : Serializer.Deserialize<T>(m));
+        // Materialized eagerly: a lazy Select would re-deserialize every element on each enumeration.
+        return result.ToFastArray(m => m == RedisValue.Null ? default : Serializer.Deserialize<T>(m));
     }
 
     /// <inheritdoc/>

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.Tags.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.Tags.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 using StackExchange.Redis.Extensions.Core.Extensions;
@@ -22,9 +21,10 @@ public partial class RedisDatabase
         if (keys.Length == 0)
             return [];
 
-        var hashKeys = new HashSet<string>();
+        var hashKeys = new HashSet<string>(keys.Length, StringComparer.Ordinal);
 
-        keys.FastIteration((key, _) => hashKeys.Add(key));
+        foreach (var key in keys)
+            hashKeys.Add(key!);
 
         var result = await GetAllAsync<T>(hashKeys, flag).ConfigureAwait(false);
 
@@ -56,8 +56,11 @@ public partial class RedisDatabase
 
         TryAddCondition(transaction, when, key);
 
-        foreach (var tagKey in tags.Select(TagHelper.GenerateTagKey))
-            transaction.SetAddAsync(tagKey, key.OfValueSize(Serializer, maxValueLength, tagKey), commandFlags);
+        // Serialized once: the previous per-tag call produced N identical byte arrays for the same key.
+        var serializedKey = key.OfValueSize(Serializer, maxValueLength, key);
+
+        foreach (var tag in tags)
+            transaction.SetAddAsync(TagHelper.GenerateTagKey(tag), serializedKey, commandFlags);
 
         action(transaction);
 

--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisDatabase.cs
@@ -109,10 +109,13 @@ public partial class RedisDatabase : IRedisDatabase
     /// <inheritdoc/>
     public async Task<T?> GetAsync<T>(string key, DateTimeOffset expiresAt, CommandFlags flag = CommandFlags.None)
     {
-        var result = await GetAsync<T>(key, flag).ConfigureAwait(false);
+        // Database resolves a pooled connection on every access: read it once for the two commands.
+        var db = Database;
+        var valueBytes = await db.StringGetAsync(key, flag).ConfigureAwait(false);
+        var result = !valueBytes.HasValue ? default : Serializer.Deserialize<T>(valueBytes);
 
         if (!EqualityComparer<T?>.Default.Equals(result, default))
-            await Database.KeyExpireAsync(key, expiresAt.UtcDateTime.Subtract(DateTime.UtcNow)).ConfigureAwait(false);
+            await db.KeyExpireAsync(key, expiresAt.UtcDateTime.Subtract(DateTime.UtcNow)).ConfigureAwait(false);
 
         return result;
     }
@@ -120,10 +123,12 @@ public partial class RedisDatabase : IRedisDatabase
     /// <inheritdoc/>
     public async Task<T?> GetAsync<T>(string key, TimeSpan expiresIn, CommandFlags flag = CommandFlags.None)
     {
-        var result = await GetAsync<T>(key, flag).ConfigureAwait(false);
+        var db = Database;
+        var valueBytes = await db.StringGetAsync(key, flag).ConfigureAwait(false);
+        var result = !valueBytes.HasValue ? default : Serializer.Deserialize<T>(valueBytes);
 
         if (!EqualityComparer<T?>.Default.Equals(result, default))
-            await Database.KeyExpireAsync(key, expiresIn).ConfigureAwait(false);
+            await db.KeyExpireAsync(key, expiresIn).ConfigureAwait(false);
 
         return result;
     }
@@ -226,10 +231,7 @@ public partial class RedisDatabase : IRedisDatabase
     /// <inheritdoc/>
     public Task<bool> AddAllAsync<T>(Tuple<string, T>[] items, When when = When.Always, CommandFlags flag = CommandFlags.None)
     {
-        var values = items
-            .OfValueInListSize(Serializer, maxValueLength)
-            .Select(x => new KeyValuePair<RedisKey, RedisValue>(x.Key, x.Value))
-            .ToArray();
+        var values = items.ToRedisEntries(Serializer, maxValueLength);
 
         return Database.StringSetAsync(values, when, flag);
     }
@@ -237,10 +239,7 @@ public partial class RedisDatabase : IRedisDatabase
     /// <inheritdoc/>
     public async Task<bool> AddAllAsync<T>(Tuple<string, T>[] items, DateTimeOffset expiresAt, When when = When.Always, CommandFlags flag = CommandFlags.None)
     {
-        var values = items
-            .OfValueInListSize(Serializer, maxValueLength)
-            .Select(x => new KeyValuePair<RedisKey, RedisValue>(x.Key, x.Value))
-            .ToArray();
+        var values = items.ToRedisEntries(Serializer, maxValueLength);
 
         if (values.Length == 0)
             return false;
@@ -265,10 +264,7 @@ public partial class RedisDatabase : IRedisDatabase
     /// <inheritdoc/>
     public async Task<bool> AddAllAsync<T>(Tuple<string, T>[] items, TimeSpan expiresAt, When when = When.Always, CommandFlags flag = CommandFlags.None)
     {
-        var values = items
-            .OfValueInListSize(Serializer, maxValueLength)
-            .Select(x => new KeyValuePair<RedisKey, RedisValue>(x.Key, x.Value))
-            .ToArray();
+        var values = items.ToRedisEntries(Serializer, maxValueLength);
 
         if (values.Length == 0)
             return false;
@@ -333,7 +329,8 @@ public partial class RedisDatabase : IRedisDatabase
 
         var items = await Database.SetPopAsync(key, count, flag).ConfigureAwait(false);
 
-        return items.Select(item => item == RedisValue.Null ? default : Serializer.Deserialize<T>(item));
+        // Materialized eagerly: a lazy Select would re-deserialize every element on each enumeration.
+        return items.ToFastArray(item => item == RedisValue.Null ? default : Serializer.Deserialize<T>(item));
     }
 
     /// <inheritdoc/>
@@ -511,22 +508,25 @@ public partial class RedisDatabase : IRedisDatabase
     {
         pattern = $"{keyPrefix}{pattern}";
         var keys = new HashSet<string>();
+        var hasPrefix = !string.IsNullOrEmpty(keyPrefix);
 
         foreach (var server in ServerIteratorFactory.GetServers(connectionPoolManager.GetConnection(), serverEnumerationStrategy))
         {
+            // The prefix is stripped while filling: a lazy Select would re-allocate every substring on each enumeration.
             await foreach (var key in server.KeysAsync(dbNumber, pattern, 1000).ConfigureAwait(false))
-                keys.Add(key!);
+                keys.Add(hasPrefix ? ((string)key!)[keyPrefix.Length..] : key!);
         }
 
-        return !string.IsNullOrEmpty(keyPrefix)
-            ? keys.Select(k => k.ToString()[keyPrefix.Length..])
-            : keys.Select(k => k.ToString());
+        return keys;
     }
 
     /// <inheritdoc/>
     public Task FlushDbAsync()
     {
-        var endPoints = Database.Multiplexer.GetEndPoints();
+        // Database resolves a pooled connection and allocates the key-prefixed wrapper on every access: read it once.
+        var db = Database;
+        var multiplexer = db.Multiplexer;
+        var endPoints = multiplexer.GetEndPoints();
 
         var tasks = new List<Task>(endPoints.Length);
 
@@ -536,10 +536,10 @@ public partial class RedisDatabase : IRedisDatabase
         {
             ref var endpoint = ref Unsafe.Add(ref searchSpace, i);
 
-            var server = Database.Multiplexer.GetServer(endpoint);
+            var server = multiplexer.GetServer(endpoint);
 
             if (!server.IsReplica)
-                tasks.Add(server.FlushDatabaseAsync(Database.Database));
+                tasks.Add(server.FlushDatabaseAsync(db.Database));
         }
 
         return Task.WhenAll(tasks);
@@ -548,9 +548,10 @@ public partial class RedisDatabase : IRedisDatabase
     /// <inheritdoc/>
     public Task SaveAsync(SaveType saveType, CommandFlags flag = CommandFlags.None)
     {
-        var endPoints = Database.Multiplexer.GetEndPoints();
+        var multiplexer = Database.Multiplexer;
+        var endPoints = multiplexer.GetEndPoints();
 
-        var tasks = endPoints.ToFastArray(endpoint => Database.Multiplexer.GetServer(endpoint).SaveAsync(saveType, flag));
+        var tasks = endPoints.ToFastArray(endpoint => multiplexer.GetServer(endpoint).SaveAsync(saveType, flag));
 
         return Task.WhenAll(tasks);
     }
@@ -621,9 +622,10 @@ public partial class RedisDatabase : IRedisDatabase
 
         // Return a dictionary of the Info Key and Info value
 
-        var result = new Dictionary<string, string>();
+        var result = new Dictionary<string, string>(data.Length);
 
-        data.FastIteration((x, _) => result.TryAdd(x.Key, x.InfoValue));
+        foreach (var detail in data)
+            result.TryAdd(detail.Key, detail.InfoValue);
 
         return result;
     }

--- a/src/core/StackExchange.Redis.Extensions.Core/ServerIteration/ServerIteratorFactory.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/ServerIteration/ServerIteratorFactory.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using StackExchange.Redis.Extensions.Core.Configuration;
 
@@ -37,10 +36,19 @@ public static class ServerIteratorFactory
                     serverEnumerationStrategy.TargetRole,
                     serverEnumerationStrategy.UnreachableServerAction);
 
-                return serversSingle.Take(1);
+                return TakeFirst(serversSingle);
 
             default:
                 throw new NotImplementedException();
+        }
+    }
+
+    private static IEnumerable<IServer> TakeFirst(ServerEnumerable servers)
+    {
+        foreach (var server in servers)
+        {
+            yield return server;
+            yield break;
         }
     }
 }

--- a/src/serializers/StackExchange.Redis.Extensions.MsgPack/MsgPackObjectSerializer.cs
+++ b/src/serializers/StackExchange.Redis.Extensions.MsgPack/MsgPackObjectSerializer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
-using System.IO;
 using System.Text;
 
 using MsgPack.Serialization;
@@ -45,13 +43,12 @@ public class MsgPackObjectSerializer : ISerializer
             return default;
 
         if (typeof(T) == typeof(string))
-            return (T)Convert.ChangeType(encoding.GetString(serializedObject), typeof(T), CultureInfo.InvariantCulture);
+            return (T)(object)encoding.GetString(serializedObject);
 
         var serializer = MessagePackSerializer.Get<T>();
 
-        using var byteStream = new MemoryStream(serializedObject);
-
-        return serializer.Unpack(byteStream);
+        // UnpackSingleObject reads the array directly, without a wrapping MemoryStream.
+        return serializer.UnpackSingleObject(serializedObject);
     }
 
     /// <inheritdoc/>
@@ -65,9 +62,7 @@ public class MsgPackObjectSerializer : ISerializer
 
         var serializer = MessagePackSerializer.Get(item.GetType());
 
-        using var byteStream = new MemoryStream();
-        serializer.Pack(byteStream, item);
-
-        return byteStream.ToArray();
+        // PackSingleObject returns the buffer directly, without MemoryStream growth plus final copy.
+        return serializer.PackSingleObject(item);
     }
 }

--- a/src/serializers/StackExchange.Redis.Extensions.Newtonsoft/NewtonsoftSerializer.cs
+++ b/src/serializers/StackExchange.Redis.Extensions.Newtonsoft/NewtonsoftSerializer.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System.Buffers;
+using System.IO;
 using System.Text;
 
 using Newtonsoft.Json;
@@ -22,11 +24,18 @@ public class NewtonsoftSerializer(JsonSerializerSettings? settings) : ISerialize
     /// </summary>
     /// <remarks>
     /// StackExchange.Redis uses Encoding.UTF8 to convert strings to bytes,
-    /// hence we do same here.
+    /// hence we do same here. The BOM is suppressed to keep the on-wire bytes
+    /// identical to the previous Encoding.UTF8.GetBytes-based implementation.
     /// </remarks>
-    private static readonly Encoding encoding = Encoding.UTF8;
+    private static readonly UTF8Encoding encoding = new(false);
 
-    private readonly JsonSerializerSettings settings = settings ?? new();
+    // Writing straight to a stream avoids materializing every payload as an intermediate UTF-16 string,
+    // and the cached serializers avoid the JsonSerializer.CreateDefault call JsonConvert performs per invocation.
+    private readonly JsonSerializer writeSerializer = JsonSerializer.CreateDefault(settings);
+
+    // JsonConvert.DeserializeObject enables CheckAdditionalContent unless explicitly configured:
+    // a dedicated instance preserves that behavior on the read path.
+    private readonly JsonSerializer readSerializer = CreateReadSerializer(settings);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NewtonsoftSerializer"/> class.
@@ -42,9 +51,13 @@ public class NewtonsoftSerializer(JsonSerializerSettings? settings) : ISerialize
         if (item == null)
             return [];
 
-        var type = item.GetType();
-        var jsonString = JsonConvert.SerializeObject(item, type, settings);
-        return encoding.GetBytes(jsonString);
+        using var ms = new MemoryStream(256);
+
+        using (var streamWriter = new StreamWriter(ms, encoding, 1024, leaveOpen: true))
+        using (var jsonWriter = new JsonTextWriter(streamWriter) { ArrayPool = JsonCharArrayPool.Instance })
+            writeSerializer.Serialize(jsonWriter, item, item.GetType());
+
+        return ms.ToArray();
     }
 
     /// <inheritdoc/>
@@ -53,7 +66,30 @@ public class NewtonsoftSerializer(JsonSerializerSettings? settings) : ISerialize
         if (serializedObject == null)
             return default;
 
-        var jsonString = encoding.GetString(serializedObject);
-        return JsonConvert.DeserializeObject<T>(jsonString, settings);
+        using var ms = new MemoryStream(serializedObject, writable: false);
+        using var streamReader = new StreamReader(ms, encoding);
+        using var jsonReader = new JsonTextReader(streamReader) { ArrayPool = JsonCharArrayPool.Instance };
+
+        return readSerializer.Deserialize<T>(jsonReader);
+    }
+
+    private static JsonSerializer CreateReadSerializer(JsonSerializerSettings? settings)
+    {
+        var serializer = JsonSerializer.CreateDefault(settings);
+        serializer.CheckAdditionalContent = true;
+        return serializer;
+    }
+
+    private sealed class JsonCharArrayPool : IArrayPool<char>
+    {
+        public static readonly JsonCharArrayPool Instance = new();
+
+        public char[] Rent(int minimumLength) => ArrayPool<char>.Shared.Rent(minimumLength);
+
+        public void Return(char[]? array)
+        {
+            if (array != null)
+                ArrayPool<char>.Shared.Return(array);
+        }
     }
 }

--- a/src/serializers/StackExchange.Redis.Extensions.Protobuf/ProtobufSerializer.cs
+++ b/src/serializers/StackExchange.Redis.Extensions.Protobuf/ProtobufSerializer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
-using System.IO;
+using System;
+using System.Buffers;
 
 using ProtoBuf;
 
@@ -19,11 +20,12 @@ public class ProtobufSerializer : ISerializer
         if (item == null)
             return [];
 
-        using var ms = new MemoryStream();
+        // IBufferWriter avoids the MemoryStream layer; the final ToArray is the only full copy.
+        var buffer = new ArrayBufferWriter<byte>(256);
 
-        Serializer.Serialize(ms, item);
+        Serializer.Serialize(buffer, item);
 
-        return ms.ToArray();
+        return buffer.WrittenSpan.ToArray();
     }
 
     /// <inheritdoc/>
@@ -32,8 +34,7 @@ public class ProtobufSerializer : ISerializer
         if (serializedObject == null)
             return default;
 
-        using var ms = new MemoryStream(serializedObject);
-
-        return Serializer.Deserialize<T>(ms);
+        // The span-based overload reads the array directly, without a wrapping MemoryStream.
+        return Serializer.Deserialize<T>((ReadOnlyMemory<byte>)serializedObject);
     }
 }

--- a/src/serializers/StackExchange.Redis.Extensions.ServiceStack/ServiceStackJsonSerializer.cs
+++ b/src/serializers/StackExchange.Redis.Extensions.ServiceStack/ServiceStackJsonSerializer.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Ugo Lattanzi.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System.IO;
+
 using ServiceStack.Text;
 
 using StackExchange.Redis.Extensions.Core;
@@ -34,8 +36,9 @@ public class ServiceStackJsonSerializer : ISerializer
         if (serializedObject == null)
             return default;
 
-        var json = JsConfig.UTF8Encoding.GetString(serializedObject);
-        return JsonSerializer.DeserializeFromString<T>(json);
+        // The stream API avoids materializing the payload as an intermediate UTF-16 string.
+        using var ms = new MemoryStream(serializedObject, writable: false);
+        return JsonSerializer.DeserializeFromStream<T>(ms);
     }
 
     /// <inheritdoc/>
@@ -44,7 +47,8 @@ public class ServiceStackJsonSerializer : ISerializer
         if (item == null)
             return [];
 
-        var json = JsonSerializer.SerializeToString(item);
-        return JsConfig.UTF8Encoding.GetBytes(json);
+        using var ms = new MemoryStream(256);
+        JsonSerializer.SerializeToStream(item, ms);
+        return ms.ToArray();
     }
 }

--- a/src/serializers/StackExchange.Redis.Extensions.Utf8Json/Utf8JsonSerializer.cs
+++ b/src/serializers/StackExchange.Redis.Extensions.Utf8Json/Utf8JsonSerializer.cs
@@ -22,6 +22,10 @@ public class Utf8JsonSerializer : ISerializer
     /// <inheritdoc/>
     public T? Deserialize<T>(byte[]? serializedObject)
     {
+        // Null-guard consistent with every other serializer: Utf8Json would throw on a null buffer.
+        if (serializedObject == null)
+            return default;
+
         return JsonSerializer.Deserialize<T?>(serializedObject);
     }
 }


### PR DESCRIPTION
## Summary

Full-codebase performance pass: reduces per-operation allocations and CPU work without any public API change. Also fixes three real bugs found during the audit. Version bumped to **13.0.1** (patch — internal changes only).

All **1754 core tests + 26 compression tests pass** on net10.0 and net9.0 against Redis 8.

---

## Connection pool (hot path of *every* operation)

Every Redis operation resolves a connection via `GetConnection()`, so this is the hottest path in the library.

- **`LeastLoaded` selection** (`RedisConnectionPoolManager.cs`): the loop re-evaluated `candidate.TotalOutstanding()` on every comparison. Each call goes through `IConnectionMultiplexer.GetCounters()`, which **allocates a `ServerCounters` snapshot** (~8 inner objects). With the default pool of 5, a single operation performed up to ~9 of these calls. The loop now caches the candidate's value — one call per connection, worst case.
- **Log argument evaluation**: `LogMessages.ConnectionSelected(..., connection.TotalOutstanding())` evaluated its arguments at the call-site even with logging disabled — one extra `GetCounters()` allocation per operation. Now guarded by `logger.IsEnabled(LogLevel.Debug)`.
- **`RoundRobin` strategy**: used `RandomNumberGenerator.GetInt32` (a cryptographic RNG, ~100-300ns per call) on net6+, and `new Random()` **allocated per call** on netstandard2.1 — and neither was actually round-robin. Replaced with a lock-free `Interlocked.Increment` counter: zero allocations, true round-robin, works on every TFM, and removes the `#if` branch. Note: distribution changes from random to sequential (which is what the strategy name promises).
- **All-disconnected fallback**: `connections.MinBy(...)` allocated a boxed enumerator and re-called `GetCounters()` per element. Replaced with an inline loop; the now-unused custom `MinBy` helper was deleted.
- **Static lock removed**: the constructor held a *static* lock during blocking network I/O (`EmitConnectionsAsync().GetAwaiter().GetResult()`), serializing pool creation process-wide with multi-client factories. The lock protected only instance state, i.e. nothing.

## Core

- **`RedisClient.Db0..Db16` / `GetDefaultDatabase`**: every access allocated a new `RedisDatabase`. Instances are immutable and stateless (the pooled connection is resolved per operation), so they are now cached per database number. Since `RedisConfiguration.KeyPrefix` is mutable at runtime, the cache entry stores the prefix it was created with and is invalidated when it changes.
- **`HashGetAsync<T>(hashKey, string[] keys)`**: issued **N parallel HGET commands** via `Parallel.ForEachAsync` + `ConcurrentDictionary` (N async state machines, N pool selections). Now a **single HMGET** — fewer round-trips, atomic to boot, and the `#if NET6_0_OR_GREATER` fork disappears.
- **`UpdateExpiryAsync`**: dropped the `EXISTS` pre-check before `EXPIRE`. `EXPIRE` already returns `false` for missing keys, and the check wasn't atomic anyway — this halves the round-trips, and `UpdateExpiryAllAsync` benefits N-fold. The DateTimeOffset overload also computes the TTL once instead of re-reading `DateTime.UtcNow` per key.
- **`AddAllAsync`** (3 overloads): replaced the `OfValueInListSize` iterator → `Select` → `ToArray` pipeline (unknown-size growth buffers) with a single pre-sized array pass.
- **Lazy `Select` returned to callers**: `SetPopAsync(count)`, `SortedSetRangeByScoreAsync`, `HashKeysAsync` returned deferred enumerables — a caller doing `Any()` + `foreach` **deserialized everything twice**. Now materialized eagerly, consistent with the rest of the codebase.
- **`SearchKeysAsync`**: the prefix-stripping `Select` re-allocated all substrings on every enumeration (and called `ToString()` on values that were already strings). The prefix is now stripped while filling the set, which is returned directly.
- **Tags**: `ExecuteAddWithTagsAsync` serialized the *same key* once per tag. Now serialized once and reused (also drops the `Select` enumerator).
- **Pub/Sub handler**: each message allocated `Task.Run` closure + task + `ContinueWith` closure + continuation object (the continuation even on success). The error handling is now a try/catch inside the same task — same offloading semantics, ~half the allocations per message.
- **`ToFastArray(ICollection<T>)`**: iterating a `List<T>` through the interface boxed its struct enumerator. Added array and `List<T>` (`CollectionsMarshal.AsSpan`, net8+) fast paths.
- **`GetAsync` with expiry, `FlushDbAsync`, `SaveAsync`**: read the `Database` property (pool selection + key-prefix wrapper allocation) multiple times per call; now read once.
- **Dead code removed**: `FastIteration` (last call-site inlined), `SpanExtensions.Any`, a duplicated null-check in `ListGetFromRightAsync`, `ServerIteratorFactory`'s LINQ `Take(1)` (replaced by a minimal iterator).

## Serializers

- **Newtonsoft**: every payload was materialized twice — UTF-16 string (~2× the bytes, LOH for large payloads) plus the UTF-8 array — and `JsonConvert` re-created the `JsonSerializer` on every call. Now: cached serializers (a dedicated read instance preserves `JsonConvert`'s `CheckAdditionalContent` behavior), stream-based write/read with `ArrayPool<char>`-backed `JsonTextWriter`/`Reader`. BOM suppressed to keep on-wire bytes identical to the previous implementation.
- **ServiceStack**: same double-materialization, fixed with `SerializeToStream`/`DeserializeFromStream`.
- **MsgPack**: `PackSingleObject`/`UnpackSingleObject` remove the MemoryStream growth + final copy; the string path drops a boxing `Convert.ChangeType` for a direct cast.
- **Protobuf**: `Deserialize` reads the array via the `ReadOnlyMemory<byte>` overload (no wrapping stream); `Serialize` writes to an `ArrayBufferWriter` (no stream layer).
- **System.Text.Json, MemoryPack, Utf8Json**: already optimal, untouched (except the Utf8Json bug below).

## Compressors

- **Snappier**: `Decompress` allocated the exact-size buffer *and then copied it again* with `ToArray()` — the copy was 100% redundant (the header-declared length always matches). `Compress` now rents the transient worst-case buffer (~1.17× input, LOH-bound above 85KB) from `ArrayPool`.
- **Brotli**: `Compress` used `BrotliStream` + growing `MemoryStream` + final copy; now one-shot `BrotliEncoder.TryCompress` into a rented buffer, with the same `CompressionLevel`→quality mapping the runtime uses. `Decompress` pre-sizes its output stream.
- **ZstdSharp**: created a new `Compressor`/`Decompressor` (zstd context) **per call** — the main zstd anti-pattern, contexts are designed for reuse. Now per-thread reused contexts (`ThreadLocal`, they are not thread-safe), plus exact-size decompression via the frame header instead of `Unwrap().ToArray()` double-copy.
- **GZip**: pre-sized `MemoryStream`s to avoid growth copies (no dependency added).
- **LZ4**: already single-allocation, untouched.

## ASP.NET Core

- **`RedisDistributedCache`**: the collection expressions `[DataField, ...]` allocated a fresh `RedisValue[]` on **every Get/Refresh**. Now static readonly arrays (same pattern as `Microsoft.Extensions.Caching.StackExchangeRedis`). `SetAsync` batches HSET + EXPIRE into a single network write instead of two sequential round-trips.
- **`RedisHealthCheck`**: intentionally untouched — it runs every 10-30s, the micro-optimizations aren't worth the complexity there.

## Bug fixes (found during the audit)

1. **`HashGetAllAsyncAtOneTimeAsync` + KeyPrefix**: the per-call Lua script embedded the hash key *unprefixed* while the hash *fields* (passed as `KEYS`) were being wrongly prefixed by the `WithKeyPrefix` wrapper — with a prefix configured, the method read the wrong hash with the wrong fields. Replaced by HMGET, which applies the prefix to the right thing. The script concatenation was also a **Lua injection vector** (a hash key containing `'` broke out of the string literal) and defeated the server-side script cache (every hashKey produced a distinct script, forcing a full Lua parse per call).
2. **`Utf8JsonSerializer.Deserialize(null)`** threw instead of returning `default` — every other serializer has the null-guard.
3. **`ListGetFromRightAsync`** had a duplicated `RedisValue.Null` check (dead code).

## Behavioral notes (reviewed, considered acceptable)

- `HashGetAsync(string[])` now returns a `Dictionary` instead of `ConcurrentDictionary` — the contract is `IDictionary<string, T?>`, only non-contractual casts would notice.
- `RoundRobin` is now sequential instead of random (arguably the fix of a misnomer).
- Pub/Sub handler errors now log the original exception instead of the wrapping `AggregateException`.

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings (TreatWarningsAsErrors on, all TFMs including netstandard2.1)
- [x] `dotnet test -f net10.0` — 1754 + 26 passed, 0 failed
- [x] `dotnet test -f net9.0` — 1754 + 26 passed, 0 failed (one flaky timing test passed on re-run)
- [x] All serializer round-trips green across the 7 serializer test suites (byte-level compat guarded by string round-trip tests)
- [x] All 5 compressor suites green, including the compression-migration error-path tests