### PR TITLE
Add `SkipEnabledCheck=true` to `ConnectionSelected` log message

### DIFF
--- a/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisConnectionPoolManager.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Implementations/RedisConnectionPoolManager.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -11,11 +12,8 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
-using System.Diagnostics;
-
 using StackExchange.Redis.Extensions.Core.Abstractions;
 using StackExchange.Redis.Extensions.Core.Configuration;
-using StackExchange.Redis.Extensions.Core.Extensions;
 using StackExchange.Redis.Extensions.Core.Logging;
 using StackExchange.Redis.Extensions.Core.Models;
 

--- a/src/core/StackExchange.Redis.Extensions.Core/Logging/LogMessages.cs
+++ b/src/core/StackExchange.Redis.Extensions.Core/Logging/LogMessages.cs
@@ -18,7 +18,7 @@ internal static partial class LogMessages
         Message = "Redis connection pool initialized: {PoolSize} connections to {Endpoint} in {ElapsedMs}ms")]
     public static partial void PoolInitialized(ILogger logger, int poolSize, string endpoint, long elapsedMs);
 
-    [LoggerMessage(EventId = 1002, Level = LogLevel.Debug,
+    [LoggerMessage(EventId = 1002, Level = LogLevel.Debug, SkipEnabledCheck = true, // Check by the caller
         Message = "Using connection {ConnectionHash} with {Outstanding} outstanding commands")]
     public static partial void ConnectionSelected(ILogger logger, int connectionHash, long outstanding);
 


### PR DESCRIPTION
## Summary

Avoid unnecessary double enabled check.

## Motivation

Closes #661 

## Changes

- Add `SkipEnabledCheck = true` to `LogMessages.ConnectionSelected`

## Checklist

- [x] Code compiles without warnings (`TreatWarningsAsErrors` is enabled)
- [x] Tests pass locally (`dotnet test`)
- [x] New code has test coverage
- [x] No breaking changes to public API (or documented in PR description)
